### PR TITLE
refactor: merge src/errors.rs into langchainx-core

### DIFF
--- a/.agents/skills/arc-dyn-llm/SKILL.md
+++ b/.agents/skills/arc-dyn-llm/SKILL.md
@@ -1,32 +1,36 @@
 ---
 name: arc-dyn-llm
-description: JOB-251 — Why Arc<dyn LLM> over LLMClone, migration pattern, and correct LLM ownership model.
+description: Arc<dyn LLM> ownership model, IntoArcLLM conversion trait, and builder patterns.
 ---
 
 <oneliner>
-The LLMClone supertrait is an anti-pattern. Prefer Arc<dyn LLM> for shared ownership —
-Arc is Clone by definition, no extra trait machinery needed.
+LLMClone is gone. Use Arc<dyn LLM> for shared ownership — Arc is Clone by definition.
+IntoArcLLM accepts both concrete types and Arc<dyn LLM> in builder .llm() methods.
 </oneliner>
 
-<problem>
-## Current Problem (JOB-251)
+<current-state>
+## Current State
 
-`LLMClone` exists solely because `dyn LLM` is not `Clone`:
+`LLMClone` and `clone_box()` have been removed. The `IntoArcLLM` conversion trait is in
+`src/language_models/llm.rs`:
 
 ```rust
-// CURRENT — anti-pattern
-pub trait LLMClone {
-    fn clone_box(&self) -> Box<dyn LLM>;
+pub trait IntoArcLLM {
+    fn into_arc_llm(self) -> Arc<dyn LLM>;
 }
-pub trait LLM: Sync + Send + LLMClone { ... }
 
-// Used only in two places:
-let stuff_chain = StuffDocumentBuilder::new().llm(llm.clone_box());
-let condense_chain = CondenseQuestionGeneratorChain::new(llm.clone_box());
+impl<L: LLM + 'static> IntoArcLLM for L {
+    fn into_arc_llm(self) -> Arc<dyn LLM> { Arc::new(self) }
+}
+
+impl IntoArcLLM for Arc<dyn LLM> {
+    fn into_arc_llm(self) -> Arc<dyn LLM> { self }
+}
 ```
 
-`clone_box()` allocates a new `Box` on every call. Every backend must also `derive(Clone)`.
-</problem>
+Builder `.llm()` methods accept `impl IntoArcLLM` — pass either a concrete LLM or an
+`Arc<dyn LLM>` directly.
+</current-state>
 
 <preferred-pattern>
 ## Preferred Pattern: Arc<dyn LLM>
@@ -37,37 +41,32 @@ use langchainx::language_models::llm::LLM;
 
 // Cheap clone — just an atomic ref count increment
 let llm: Arc<dyn LLM> = Arc::new(Claude::new());
-let llm2 = Arc::clone(&llm);  // no Box allocation, no clone_box()
 
 // Both chains share the same LLM instance
-let stuff_chain = StuffDocumentBuilder::new().llm(Arc::clone(&llm));
-let condense_chain = CondenseQuestionGeneratorChain::new(Arc::clone(&llm));
+let stuff_chain = StuffDocumentBuilder::new().llm(Arc::clone(&llm)).build()?;
+let condense_chain = ConversationalRetrieverChainBuilder::new().llm(Arc::clone(&llm));
 ```
 
 </preferred-pattern>
 
-<current-workaround>
-## Current Workaround (until JOB-251 is resolved)
+<concrete-llm>
+## Passing a Concrete LLM to a Builder
 
-`clone_box()` still works today. If you must clone an LLM to pass to two builders:
+Builders accept concrete types directly via `IntoArcLLM`:
 
 ```rust
-// Acceptable today — will be removed when JOB-251 is implemented
-let llm: Box<dyn LLM> = Box::new(OpenAI::default());
-let stuff = StuffDocumentBuilder::new().llm(llm.clone_box()).build()?;
-let condense = CondenseQuestionGeneratorChain::new(llm.clone_box());
+// Concrete type — builder wraps it in Arc internally
+let chain = LLMChainBuilder::new()
+    .llm(OpenAI::default())
+    .prompt(prompt)
+    .build()?;
+
+// Arc<dyn LLM> — also accepted
+let llm: Arc<dyn LLM> = Arc::new(OpenAI::default());
+let chain = LLMChainBuilder::new()
+    .llm(llm)
+    .prompt(prompt)
+    .build()?;
 ```
 
-Do NOT add new code that introduces new `clone_box()` call sites. Prefer Arc.
-</current-workaround>
-
-<migration>
-## Migration Checklist (implementing JOB-251)
-
-1. Remove `LLMClone` supertrait from `LLM` definition
-2. Remove blanket `impl<T: LLM + Clone> LLMClone for T`
-3. Change `Box<dyn LLM>` fields → `Arc<dyn LLM>` in all chain structs
-4. Change `From<L> for Box<dyn LLM>` → `From<L> for Arc<dyn LLM>`
-5. Replace all `llm.clone_box()` call sites with `Arc::clone(&llm)`
-6. Update builder `.llm()` method signatures to accept `impl Into<Arc<dyn LLM>>`
-   </migration>
+</concrete-llm>

--- a/.agents/skills/error-handling/SKILL.md
+++ b/.agents/skills/error-handling/SKILL.md
@@ -1,74 +1,35 @@
 ---
 name: error-handling
-description: JOB-255 — replacing Box<dyn Error> on Tool::run with typed ToolError, thiserror patterns.
+description: ToolError on Tool::run and Tool::call, thiserror patterns, and existing error types per module.
 ---
 
 <oneliner>
-Tool::run currently returns Box<dyn Error> — opaque, not matchable. New tools should
-internally use typed errors and convert at the boundary. When JOB-255 lands, Tool::run
-returns ToolError.
+Tool::run and Tool::call return ToolError (not Box<dyn Error>). Use thiserror for
+typed internal errors and convert via ToolError::Other for external error types.
 </oneliner>
 
 <current-state>
 ## Current State
 
 ```rust
-// Tool trait today
-async fn run(&self, input: Value) -> Result<String, Box<dyn Error>>;
-async fn call(&self, input: &str) -> Result<String, Box<dyn Error>>;
+// Tool trait — actual signatures
+async fn run(&self, input: Value) -> Result<String, ToolError>;
+async fn call(&self, input: &str) -> Result<String, ToolError>;
 ```
 
-`AgentExecutor` receives the error and stringifies it:
+`AgentExecutor` receives the error and stringifies it for the agent:
 
 ```rust
 Err(err) => format!("The tool return the following error: {}", err)
 ```
 
-All error type information is lost. The agent sees a plain string.
 </current-state>
 
-<correct-pattern>
-## Correct Pattern: Typed Errors in Implementations
-
-Even while `Box<dyn Error>` is the return type, define internal typed errors and convert:
+<toolerror>
+## ToolError
 
 ```rust
-use thiserror::Error;
-
-#[derive(Debug, Error)]
-enum MyToolError {
-    #[error("invalid input: {0}")]
-    InvalidInput(String),
-    #[error("API request failed: {0}")]
-    RequestFailed(#[from] reqwest::Error),
-    #[error("parse error: {0}")]
-    ParseError(String),
-}
-
-pub struct MyTool;
-
-#[async_trait]
-impl Tool for MyTool {
-    async fn run(&self, input: Value) -> Result<String, Box<dyn std::error::Error>> {
-        let query = input.as_str()
-            .ok_or_else(|| MyToolError::InvalidInput("expected string".into()))?;
-
-        let result = call_api(query).await
-            .map_err(MyToolError::RequestFailed)?;
-
-        Ok(result)
-    }
-    // ...
-}
-```
-
-</correct-pattern>
-
-<future-toolerror>
-## Future ToolError (JOB-255 target)
-
-```rust
-// Will replace Box<dyn Error> once JOB-255 is implemented
+// src/tools/error.rs
 #[derive(Debug, thiserror::Error)]
 pub enum ToolError {
     #[error("invalid input: {0}")]
@@ -80,24 +41,55 @@ pub enum ToolError {
 }
 ```
 
-Migration: change `run()` and `call()` signatures. Update `AgentExecutor` to pattern-match
-`ToolError` variants and decide whether to break or continue.
-</future-toolerror>
+Use `ToolError::InvalidInput` for bad user input, `ToolError::ExecutionFailed` for
+runtime failures, and `ToolError::Other` to wrap external errors via `?`.
+</toolerror>
+
+<correct-pattern>
+## Correct Pattern: Typed Errors in Implementations
+
+```rust
+use langchainx::tools::{Tool, ToolError};
+use serde_json::Value;
+
+pub struct MyTool;
+
+#[async_trait::async_trait]
+impl Tool for MyTool {
+    fn name(&self) -> String { "my_tool".to_string() }
+    fn description(&self) -> String { "Does something useful.".to_string() }
+
+    async fn run(&self, input: Value) -> Result<String, ToolError> {
+        let query = input.as_str()
+            .ok_or_else(|| ToolError::InvalidInput("expected string".into()))?;
+
+        let result = call_api(query).await
+            .map_err(|e| ToolError::Other(Box::new(e)))?;
+
+        Ok(result)
+    }
+}
+```
+
+For external errors that implement `std::error::Error + Send + Sync`, the `From` impl
+on `ToolError::Other` allows `?` to work directly.
+</correct-pattern>
 
 <existing-error-types>
 ## Existing Error Types
 
-Each module already has a typed error via `thiserror`:
+Each module has a typed error via `thiserror`:
 
 | Module           | Error type      |
 | ---------------- | --------------- |
 | LLM              | `LLMError`      |
 | Chain            | `ChainError`    |
 | Agent            | `AgentError`    |
+| Tool             | `ToolError`     |
 | Embedding        | `EmbedderError` |
 | Prompt           | `PromptError`   |
 | Document loaders | `LoaderError`   |
 
-Use these when implementing new code in those modules. Do not introduce new `Box<dyn Error>`
-return types in non-Tool code.
+Use these when implementing new code in those modules. Do not introduce `Box<dyn Error>`
+return types anywhere.
 </existing-error-types>

--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -1,80 +1,38 @@
 ---
 name: testing
-description: JOB-257 — FakeLLM, in-process test doubles, writing offline chain/agent tests.
+description: FakeLLM, in-process test doubles, writing offline chain/agent tests.
 ---
 
 <oneliner>
-Every chain test is currently #[ignore] because there is no FakeLLM. Use FakeLLM from
-src/test_utils to write offline tests. Never call real APIs in unit tests.
+FakeLLM is in src/test_utils/ and already implemented. Use it for offline chain tests.
+Never call real APIs in unit tests. FakeLLM::new takes Vec<String>.
 </oneliner>
 
-<current-state>
-## Current State (JOB-257)
-
-Every chain and agent test is gated by `#[ignore]`:
-
-```rust
-#[tokio::test]
-#[ignore]  // requires live OPENAI_API_KEY
-async fn test_invoke_chain() { ... }
-```
-
-There is zero automated test coverage for chain or agent behavior.
-</current-state>
-
 <fakellm>
-## FakeLLM (implement in src/test_utils.rs)
+## FakeLLM
+
+`FakeLLM` is already implemented at `src/test_utils/fake_llm.rs` and re-exported from
+`langchainx::test_utils::FakeLLM`.
 
 ```rust
-// src/test_utils.rs — gated behind #[cfg(any(test, feature = "test-utils"))]
-use std::collections::VecDeque;
-use std::sync::{Arc, atomic::{AtomicUsize, Ordering}};
-use tokio::sync::Mutex;
-use async_trait::async_trait;
-use langchainx::{
-    language_models::{llm::LLM, options::CallOptions, GenerateResult, LLMError},
-    schemas::{Message, StreamData},
-};
+use langchainx::test_utils::FakeLLM;
 
-#[derive(Clone)]
-pub struct FakeLLM {
-    pub responses: Arc<Mutex<VecDeque<String>>>,
-    pub call_count: Arc<AtomicUsize>,
-}
+let llm = FakeLLM::new(vec![
+    "Hello from FakeLLM!".to_string(),
+    "Second response".to_string(),
+]);
 
-impl FakeLLM {
-    pub fn new(responses: Vec<&str>) -> Self {
-        Self {
-            responses: Arc::new(Mutex::new(
-                responses.into_iter().map(String::from).collect()
-            )),
-            call_count: Arc::new(AtomicUsize::new(0)),
-        }
-    }
-
-    pub fn call_count(&self) -> usize {
-        self.call_count.load(Ordering::SeqCst)
-    }
-}
-
-#[async_trait]
-impl LLM for FakeLLM {
-    async fn generate(&self, _messages: &[Message]) -> Result<GenerateResult, LLMError> {
-        self.call_count.fetch_add(1, Ordering::SeqCst);
-        let mut responses = self.responses.lock().await;
-        let generation = responses.pop_front().unwrap_or_default();
-        Ok(GenerateResult { generation, ..Default::default() })
-    }
-
-    async fn stream(
-        &self,
-        _messages: &[Message],
-    ) -> Result<std::pin::Pin<Box<dyn futures::Stream<Item = Result<StreamData, LLMError>> + Send>>, LLMError> {
-        unimplemented!("FakeLLM::stream — use FakeStreamingLLM for stream tests")
-    }
-}
+// Responses are popped in order; empty string when exhausted
+assert_eq!(llm.invoke("anything").await.unwrap(), "Hello from FakeLLM!");
+assert_eq!(llm.call_count(), 1);
+assert_eq!(llm.remaining(), 1);
 ```
 
+Key details:
+- `FakeLLM::new` takes `Vec<String>` (not `Vec<&str>`)
+- `.clone()` shares the same queue — both clones see the same state
+- `.stream()` returns `Err` — use `FakeLLM` only for `generate`/`invoke` tests
+- Uses `std::sync::Mutex` (not tokio) for the response queue
 </fakellm>
 
 <writing-tests>
@@ -83,18 +41,17 @@ impl LLM for FakeLLM {
 ```rust
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::test_utils::FakeLLM;
     use langchainx::{
         chain::{Chain, LLMChainBuilder},
         message_formatter, fmt_template,
         prompt::{HumanMessagePromptTemplate, MessageOrTemplate},
         prompt_args, template_fstring,
+        test_utils::FakeLLM,
     };
 
     #[tokio::test]
     async fn test_llm_chain_invoke() {
-        let fake = FakeLLM::new(vec!["Hello from FakeLLM!"]);
+        let fake = FakeLLM::new(vec!["Hello from FakeLLM!".to_string()]);
 
         let prompt = message_formatter![
             fmt_template!(HumanMessagePromptTemplate::new(
@@ -114,14 +71,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_chain_returns_error_on_empty_responses() {
+    async fn test_chain_returns_empty_when_no_responses() {
         let fake = FakeLLM::new(vec![]); // no responses queued
-        let chain = LLMChainBuilder::new()
-            .llm(fake)
-            .prompt(prompt)
-            .build()
-            .unwrap();
-
+        // ... build chain ...
         let result = chain.invoke(prompt_args! { "input" => "Hi" }).await.unwrap();
         assert_eq!(result, ""); // unwrap_or_default in FakeLLM
     }
@@ -156,7 +108,7 @@ async fn test_chain_with_real_generation() {
     use langchainx::llm::ollama::client::Ollama;
 
     let llm = Ollama::default()
-        .with_model("qwen2.5:0.5b")  // smallest available
+        .with_model("qwen2.5:0.5b")
         .with_base_url("http://localhost:11434");
 
     let chain = LLMChainBuilder::new()
@@ -169,13 +121,11 @@ async fn test_chain_with_real_generation() {
         "input" => "Say only the word 'pong'."
     }).await.unwrap();
 
-    assert!(result.to_lowercase().contains("pong"));
+    assert!(!result.is_empty(), "model returned no output");
 }
 ```
 
 ### Feature Flag
-
-Add to `Cargo.toml` to gate local-LLM tests separately from cloud tests:
 
 ```toml
 [features]
@@ -190,29 +140,20 @@ cargo test --features local-llm-tests -- --ignored
 
 ### What to Assert
 
-Local LLM tests should verify **doneness, not correctness**. The model completed the task
-and returned something — not that it returned a specific string.
+Local LLM tests should verify **doneness, not correctness** — the chain completed without
+error and returned something, not that it returned a specific string.
 
 ```rust
 // WRONG — brittle, model-dependent phrasing
 assert_eq!(result, "The capital of France is Paris.");
-assert!(result.contains("Paris"));
 
 // CORRECT — verify task completion
 assert!(!result.is_empty(), "model returned no output");
 assert!(result.len() > 10, "response too short to be a real answer");
 
-// CORRECT — verify structural properties, not content
-assert!(result.trim().ends_with('.') || result.trim().ends_with('?') || result.trim().ends_with('!'),
-    "response should be a complete sentence");
-
 // CORRECT — for agent/tool tests, verify the tool was called
-assert!(executor_called_tool, "agent should have invoked the tool");
 assert!(!result.is_empty(), "agent should have produced a final answer");
 ```
-
-Test failure means the chain/agent **broke** (panicked, returned error, returned empty),
-not that the model gave a different phrasing than expected.
 
 ### Model Selection Guide
 
@@ -222,17 +163,18 @@ not that the model gave a different phrasing than expected.
 | `llama3.2:1b`  | 1.3GB | chain flow tests, multi-turn memory         |
 | `phi3:mini`    | 2.2GB | agent tool-use loop tests                   |
 
-Always use the smallest model that passes the test — prefer `qwen2.5:0.5b` by default.
+Always use the smallest model that passes the test.
 </local-llm>
 
 <rules>
 ## Testing Rules
 
 - Unit tests: use FakeLLM — no network, no model, deterministic
-- Tests needing real generation: use Ollama local models, gate with `#[cfg_attr(not(feature = "local-llm-tests"), ignore)]`
+- Tests needing real generation: use Ollama local models, gate with
+  `#[cfg_attr(not(feature = "local-llm-tests"), ignore)]`
 - Cloud API tests: stay `#[ignore]` in `tests/integration/`, require explicit env var
 - Remove `#[ignore]` only after replacing the live-API call with FakeLLM or local Ollama
 - Use `assert_eq!(fake.call_count(), N)` to verify chain invocation counts
-- For error-path tests, implement a `FailingLLM` that always returns `Err(LLMError::...)`
+- For error-path tests, implement a struct that returns `Err(LLMError::...)` from `generate`
 - Never use `OPENAI_API_KEY` or `CLAUDE_API_KEY` in automated CI
-  </rules>
+</rules>

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run -p xtask --"

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,51 @@
+name: triage
+
+# Assigns a P-tag label to every newly opened or reopened issue based on
+# title/body keyword heuristics. Existing P-tags are not overwritten.
+
+on:
+  issues:
+    types: [opened, reopened]
+
+permissions:
+  issues: write
+
+concurrency:
+  group: triage-issue-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  assign-priority:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip if P-tag already present
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ github.event.issue.number }}
+        run: |
+          labels=$(gh issue view "$ISSUE" --repo "$GITHUB_REPOSITORY" --json labels -q '.labels[].name')
+          if echo "$labels" | grep -qE '^P[123]$'; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Assign P-tag
+        if: steps.check.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ github.event.issue.number }}
+          TITLE: ${{ github.event.issue.title }}
+          BODY: ${{ github.event.issue.body }}
+        run: |
+          text="${TITLE} ${BODY:-}"
+          if echo "$text" | grep -qiE 'bug|broken|panic|regression|security|crash|vuln'; then
+            priority="P1"
+          elif echo "$text" | grep -qiE 'refactor|extract|feat|implement|add|improve|perf'; then
+            priority="P2"
+          else
+            priority="P3"
+          fi
+          gh issue edit "$ISSUE" --repo "$GITHUB_REPOSITORY" --add-label "$priority"
+          echo "Assigned $priority to issue #$ISSUE"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/langchainx-embedding",
     "crates/langchainx-chain",
     "examples/vector_store_surrealdb",
+    "xtask",
 ]
 
 [workspace.package]

--- a/crates/langchainx-chain/src/chain.rs
+++ b/crates/langchainx-chain/src/chain.rs
@@ -11,8 +11,8 @@ pub use crate::sequential::*;
 pub use crate::sql_datbase::*;
 
 // Sub-module re-exports for `crate::chain::X::Y` paths used in chain files/tests
-pub use crate::llm_chain as llm_chain;
-pub use crate::options as options;
-pub use crate::chain_trait as chain_trait;
-pub use crate::conversational as conversational;
+pub use crate::chain_trait;
+pub use crate::conversational;
+pub use crate::llm_chain;
+pub use crate::options;
 pub use crate::stuff_documents::*;

--- a/crates/langchainx-chain/src/chain_trait.rs
+++ b/crates/langchainx-chain/src/chain_trait.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, pin::Pin};
 
 use async_trait::async_trait;
 use futures::Stream;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::{language_models::GenerateResult, prompt::PromptArgs, schemas::StreamData};
 

--- a/crates/langchainx-chain/src/conversational/builder.rs
+++ b/crates/langchainx-chain/src/conversational/builder.rs
@@ -4,7 +4,7 @@ use tokio::sync::Mutex;
 
 use crate::{
     chain::{
-        llm_chain::LLMChainBuilder, options::ChainCallOptions, ChainError, DEFAULT_OUTPUT_KEY,
+        ChainError, DEFAULT_OUTPUT_KEY, llm_chain::LLMChainBuilder, options::ChainCallOptions,
     },
     language_models::llm::{IntoArcLLM, LLM},
     memory::SimpleMemory,
@@ -14,7 +14,7 @@ use crate::{
     template_fstring,
 };
 
-use super::{prompt::DEFAULT_TEMPLATE, ConversationalChain, DEFAULT_INPUT_VARIABLE};
+use super::{ConversationalChain, DEFAULT_INPUT_VARIABLE, prompt::DEFAULT_TEMPLATE};
 
 pub struct ConversationalChainBuilder {
     llm: Option<Arc<dyn LLM>>,

--- a/crates/langchainx-chain/src/conversational/mod.rs
+++ b/crates/langchainx-chain/src/conversational/mod.rs
@@ -3,19 +3,19 @@ use std::{pin::Pin, sync::Arc};
 use async_stream::stream;
 use async_trait::async_trait;
 use futures::Stream;
-use futures_util::{pin_mut, StreamExt};
+use futures_util::{StreamExt, pin_mut};
 use tokio::sync::Mutex;
 
 use crate::{
     language_models::GenerateResult,
     prompt::PromptArgs,
     prompt_args,
-    schemas::{memory::BaseMemory, messages::Message, StreamData},
+    schemas::{StreamData, memory::BaseMemory, messages::Message},
 };
 
 const DEFAULT_INPUT_VARIABLE: &str = "input";
 
-use super::{chain_trait::Chain, llm_chain::LLMChain, ChainError};
+use super::{ChainError, chain_trait::Chain, llm_chain::LLMChain};
 
 pub mod builder;
 mod prompt;
@@ -136,7 +136,7 @@ impl Chain for ConversationalChain {
 #[cfg(test)]
 mod tests {
     use crate::{
-        chain::{conversational::builder::ConversationalChainBuilder, Chain},
+        chain::{Chain, conversational::builder::ConversationalChainBuilder},
         prompt_args,
         test_utils::FakeLLM,
     };

--- a/crates/langchainx-chain/src/conversational_retrieval_qa/builder.rs
+++ b/crates/langchainx-chain/src/conversational_retrieval_qa/builder.rs
@@ -3,7 +3,7 @@ use tokio::sync::Mutex;
 
 use crate::{
     chain::{
-        Chain, ChainError, CondenseQuestionGeneratorChain, StuffDocumentBuilder, DEFAULT_OUTPUT_KEY,
+        Chain, ChainError, CondenseQuestionGeneratorChain, DEFAULT_OUTPUT_KEY, StuffDocumentBuilder,
     },
     language_models::llm::{IntoArcLLM, LLM},
     memory::SimpleMemory,

--- a/crates/langchainx-chain/src/conversational_retrieval_qa/conversational_retrieval_qa.rs
+++ b/crates/langchainx-chain/src/conversational_retrieval_qa/conversational_retrieval_qa.rs
@@ -1,15 +1,15 @@
 use futures::Stream;
-use futures_util::{pin_mut, StreamExt};
+use futures_util::{StreamExt, pin_mut};
 use std::{collections::HashMap, pin::Pin, sync::Arc};
 
 use async_stream::stream;
 use async_trait::async_trait;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use tokio::sync::Mutex;
 
 use crate::{
     chain::{
-        Chain, ChainError, CondenseQuestionPromptBuilder, StuffQAPromptBuilder, DEFAULT_RESULT_KEY,
+        Chain, ChainError, CondenseQuestionPromptBuilder, DEFAULT_RESULT_KEY, StuffQAPromptBuilder,
     },
     language_models::{GenerateResult, TokenUsage},
     prompt::PromptArgs,

--- a/crates/langchainx-chain/src/lib.rs
+++ b/crates/langchainx-chain/src/lib.rs
@@ -1,16 +1,16 @@
 // Re-export upstream crates so `crate::language_models`, `crate::schemas`,
 // `crate::prompt`, `crate::output_parsers` all resolve within this crate.
 // Use langchainx_llm::language_models (superset: includes LLM, LLMError, CallOptions + core types).
-pub use langchainx_llm::language_models;
 pub use langchainx_core::schemas;
+pub use langchainx_llm::language_models;
+pub use langchainx_memory as memory;
 pub use langchainx_output_parsers as output_parsers;
 pub use langchainx_prompt::prompt;
-pub use langchainx_memory as memory;
 
 // Macro re-exports from langchainx-prompt
 pub use langchainx_prompt::{
-    fmt_message, fmt_placeholder, fmt_template, message_formatter, prompt_args,
-    template_fstring, template_jinja2,
+    fmt_message, fmt_placeholder, fmt_template, message_formatter, prompt_args, template_fstring,
+    template_jinja2,
 };
 
 // Compatibility module: `crate::chain::X` paths used within chain files

--- a/crates/langchainx-chain/src/llm_chain.rs
+++ b/crates/langchainx-chain/src/llm_chain.rs
@@ -7,15 +7,15 @@ use futures_util::TryStreamExt;
 
 use crate::{
     language_models::{
-        llm::{IntoArcLLM, LLM},
         GenerateResult,
+        llm::{IntoArcLLM, LLM},
     },
     output_parsers::{OutputParser, SimpleParser},
     prompt::{FormatPrompter, PromptArgs},
     schemas::StreamData,
 };
 
-use super::{chain_trait::Chain, options::ChainCallOptions, ChainError};
+use super::{ChainError, chain_trait::Chain, options::ChainCallOptions};
 
 pub struct LLMChainBuilder {
     prompt: Option<Box<dyn FormatPrompter>>,

--- a/crates/langchainx-chain/src/question_answering.rs
+++ b/crates/langchainx-chain/src/question_answering.rs
@@ -4,15 +4,15 @@ use async_trait::async_trait;
 use futures::Stream;
 
 use crate::{
-    language_models::{llm::IntoArcLLM, GenerateResult},
+    language_models::{GenerateResult, llm::IntoArcLLM},
     prompt::PromptArgs,
     prompt_args,
-    schemas::{messages::Message, Document, StreamData},
+    schemas::{Document, StreamData, messages::Message},
     template_jinja2,
 };
 
 use super::{
-    options::ChainCallOptions, Chain, ChainError, LLMChain, LLMChainBuilder, StuffDocument,
+    Chain, ChainError, LLMChain, LLMChainBuilder, StuffDocument, options::ChainCallOptions,
 };
 
 const DEFAULTCONDENSEQUESTIONTEMPLATE: &str = r#"Given the following conversation and a follow up question, rephrase the follow up question to be a standalone question, in its original language.
@@ -66,7 +66,7 @@ impl CondenseQuestionGeneratorChain {
             .prompt(condense_question_prompt_template)
             .build()
             .unwrap(); //Its safe to unwrap here because we are sure that the prompt and the LLM are
-                       //set.
+        //set.
         Self { chain }
     }
 

--- a/crates/langchainx-chain/src/sequential/chain.rs
+++ b/crates/langchainx-chain/src/sequential/chain.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use async_trait::async_trait;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::{
     chain::{Chain, ChainError, DEFAULT_OUTPUT_KEY, DEFAULT_RESULT_KEY},

--- a/crates/langchainx-chain/src/sql_datbase/builder.rs
+++ b/crates/langchainx-chain/src/sql_datbase/builder.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::{
     chain::{
-        llm_chain::LLMChainBuilder, options::ChainCallOptions, ChainError, DEFAULT_OUTPUT_KEY,
+        ChainError, DEFAULT_OUTPUT_KEY, llm_chain::LLMChainBuilder, options::ChainCallOptions,
     },
     language_models::llm::{IntoArcLLM, LLM},
     output_parsers::OutputParser,
@@ -12,9 +12,9 @@ use crate::{
 };
 
 use super::{
+    STOP_WORD,
     chain::SQLDatabaseChain,
     prompt::{DEFAULT_SQLSUFFIX, DEFAULT_SQLTEMPLATE},
-    STOP_WORD,
 };
 
 pub struct SQLDatabaseChainBuilder {

--- a/crates/langchainx-chain/src/sql_datbase/chain.rs
+++ b/crates/langchainx-chain/src/sql_datbase/chain.rs
@@ -5,7 +5,7 @@ use futures::Stream;
 use serde_json::Value;
 
 use crate::{
-    chain::{chain_trait::Chain, llm_chain::LLMChain, ChainError},
+    chain::{ChainError, chain_trait::Chain, llm_chain::LLMChain},
     language_models::{GenerateResult, TokenUsage},
     prompt::PromptArgs,
     prompt_args,

--- a/crates/langchainx-chain/src/stuff_documents/builder.rs
+++ b/crates/langchainx-chain/src/stuff_documents/builder.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::{
-    chain::{options::ChainCallOptions, ChainError, LLMChainBuilder},
+    chain::{ChainError, LLMChainBuilder, options::ChainCallOptions},
     language_models::llm::{IntoArcLLM, LLM},
     output_parsers::OutputParser,
     prompt::FormatPrompter,

--- a/crates/langchainx-chain/src/stuff_documents/chain.rs
+++ b/crates/langchainx-chain/src/stuff_documents/chain.rs
@@ -6,11 +6,11 @@ use serde_json::Value;
 
 use crate::{
     chain::{
-        load_stuff_qa, options::ChainCallOptions, Chain, ChainError, LLMChain, StuffQAPromptBuilder,
+        Chain, ChainError, LLMChain, StuffQAPromptBuilder, load_stuff_qa, options::ChainCallOptions,
     },
     language_models::{
-        llm::{IntoArcLLM, LLM},
         GenerateResult,
+        llm::{IntoArcLLM, LLM},
     },
     prompt::PromptArgs,
     schemas::{Document, StreamData},

--- a/crates/langchainx-core/src/language_models/mod.rs
+++ b/crates/langchainx-core/src/language_models/mod.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct GenerateResult {
     pub tokens: Option<TokenUsage>,

--- a/crates/langchainx-core/src/schemas/agent.rs
+++ b/crates/langchainx-core/src/schemas/agent.rs
@@ -33,7 +33,6 @@ pub enum AgentEvent {
     Finish(AgentFinish),
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/langchainx-core/src/schemas/mod.rs
+++ b/crates/langchainx-core/src/schemas/mod.rs
@@ -16,7 +16,6 @@ pub use document::*;
 mod retrievers;
 pub use retrievers::*;
 
-
 pub mod convert;
 mod stream;
 

--- a/crates/langchainx-embedding/src/embedding/mistralai/mistralai_embedder.rs
+++ b/crates/langchainx-embedding/src/embedding/mistralai/mistralai_embedder.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::embedding::{embedder_trait::Embedder, EmbedderError};
+use crate::embedding::{EmbedderError, embedder_trait::Embedder};
 use async_trait::async_trait;
 use mistralai_client::v1::{client::Client, constants::EmbedModel};
 

--- a/crates/langchainx-embedding/src/embedding/ollama/ollama_embedder.rs
+++ b/crates/langchainx-embedding/src/embedding/ollama/ollama_embedder.rs
@@ -1,13 +1,13 @@
 use std::sync::Arc;
 
-use crate::embedding::{embedder_trait::Embedder, EmbedderError};
+use crate::embedding::{EmbedderError, embedder_trait::Embedder};
 use async_trait::async_trait;
 use ollama_rs::{
+    Ollama as OllamaClient,
     generation::{
         embeddings::request::{EmbeddingsInput, GenerateEmbeddingsRequest},
         options::GenerationOptions,
     },
-    Ollama as OllamaClient,
 };
 
 #[derive(Debug)]

--- a/crates/langchainx-embedding/src/embedding/openai/openai_embedder.rs
+++ b/crates/langchainx-embedding/src/embedding/openai/openai_embedder.rs
@@ -1,10 +1,10 @@
 #![allow(dead_code)]
 
-use crate::embedding::{embedder_trait::Embedder, EmbedderError};
+use crate::embedding::{EmbedderError, embedder_trait::Embedder};
 pub use async_openai::config::{AzureConfig, Config, OpenAIConfig};
 use async_openai::{
-    types::{CreateEmbeddingRequestArgs, EmbeddingInput},
     Client,
+    types::{CreateEmbeddingRequestArgs, EmbeddingInput},
 };
 use async_trait::async_trait;
 

--- a/crates/langchainx-embedding/src/lib.rs
+++ b/crates/langchainx-embedding/src/lib.rs
@@ -1,5 +1,5 @@
-pub use langchainx_core::schemas;
 pub use langchainx_core::language_models;
+pub use langchainx_core::schemas;
 
 pub mod embedding;
 pub use embedding::*;

--- a/crates/langchainx-llm/src/claude/client.rs
+++ b/crates/langchainx-llm/src/claude/client.rs
@@ -1,6 +1,6 @@
 use crate::{
-    language_models::{llm::LLM, options::CallOptions, GenerateResult, LLMError, TokenUsage},
     AnthropicError,
+    language_models::{GenerateResult, LLMError, TokenUsage, llm::LLM, options::CallOptions},
     schemas::{Message, MessageType, StreamData},
 };
 use async_trait::async_trait;

--- a/crates/langchainx-llm/src/deepseek/client.rs
+++ b/crates/langchainx-llm/src/deepseek/client.rs
@@ -1,6 +1,6 @@
 use crate::{
-    language_models::{llm::LLM, options::CallOptions, GenerateResult, LLMError, TokenUsage},
     DeepseekError,
+    language_models::{GenerateResult, LLMError, TokenUsage, llm::LLM, options::CallOptions},
     schemas::{Message, StreamData},
 };
 use async_trait::async_trait;

--- a/crates/langchainx-llm/src/language_models/llm.rs
+++ b/crates/langchainx-llm/src/language_models/llm.rs
@@ -6,7 +6,7 @@ use futures::Stream;
 
 use crate::schemas::{Message, StreamData};
 
-use super::{options::CallOptions, GenerateResult, LLMError};
+use super::{GenerateResult, LLMError, options::CallOptions};
 
 #[async_trait]
 pub trait LLM: Sync + Send {

--- a/crates/langchainx-llm/src/lib.rs
+++ b/crates/langchainx-llm/src/lib.rs
@@ -1,4 +1,3 @@
-
 pub mod language_models;
 pub mod schemas;
 

--- a/crates/langchainx-llm/src/ollama/client.rs
+++ b/crates/langchainx-llm/src/ollama/client.rs
@@ -51,39 +51,31 @@ impl Ollama {
     }
 
     fn generate_request(&self, messages: &[Message]) -> ChatMessageRequest {
-        let mapped_messages = messages.iter().map(|message| message.into()).collect();
+        let mapped_messages = messages.iter().map(to_chat_message).collect();
         ChatMessageRequest::new(self.model.clone(), mapped_messages)
     }
 }
 
-impl From<&Message> for ChatMessage {
-    fn from(message: &Message) -> Self {
-        let images = match message.images.clone() {
-            Some(images) => {
-                let images = images
-                    .iter()
-                    .map(|image| Image::from_base64(&image.image_url))
-                    .collect();
-                Some(images)
-            }
-            None => None,
-        };
-        ChatMessage {
-            content: message.content.clone(),
-            images,
-            role: message.message_type.clone().into(),
-        }
+fn to_message_role(message_type: MessageType) -> MessageRole {
+    match message_type {
+        MessageType::AIMessage => MessageRole::Assistant,
+        MessageType::ToolMessage => MessageRole::Assistant,
+        MessageType::SystemMessage => MessageRole::System,
+        MessageType::HumanMessage => MessageRole::User,
     }
 }
 
-impl From<MessageType> for MessageRole {
-    fn from(message_type: MessageType) -> Self {
-        match message_type {
-            MessageType::AIMessage => MessageRole::Assistant,
-            MessageType::ToolMessage => MessageRole::Assistant,
-            MessageType::SystemMessage => MessageRole::System,
-            MessageType::HumanMessage => MessageRole::User,
-        }
+fn to_chat_message(message: &Message) -> ChatMessage {
+    let images = message.images.as_ref().map(|images| {
+        images
+            .iter()
+            .map(|image| Image::from_base64(&image.image_url))
+            .collect()
+    });
+    ChatMessage {
+        content: message.content.clone(),
+        images,
+        role: to_message_role(message.message_type.clone()),
     }
 }
 

--- a/crates/langchainx-llm/src/ollama/client.rs
+++ b/crates/langchainx-llm/src/ollama/client.rs
@@ -1,17 +1,17 @@
 use crate::{
-    language_models::{llm::LLM, GenerateResult, LLMError, TokenUsage},
+    language_models::{GenerateResult, LLMError, TokenUsage, llm::LLM},
     schemas::{Message, MessageType, StreamData},
 };
 use async_trait::async_trait;
 use futures::Stream;
 use ollama_rs::generation::images::Image;
 pub use ollama_rs::{
+    Ollama as OllamaClient,
     error::OllamaError,
     generation::{
-        chat::{request::ChatMessageRequest, ChatMessage, MessageRole},
+        chat::{ChatMessage, MessageRole, request::ChatMessageRequest},
         options::GenerationOptions,
     },
-    Ollama as OllamaClient,
 };
 use std::pin::Pin;
 use std::sync::Arc;

--- a/crates/langchainx-llm/src/openai/mod.rs
+++ b/crates/langchainx-llm/src/openai/mod.rs
@@ -4,6 +4,7 @@ pub use async_openai::config::{AzureConfig, Config, OpenAIConfig};
 
 use async_openai::types::{ChatCompletionToolChoiceOption, ResponseFormat};
 use async_openai::{
+    Client,
     error::OpenAIError,
     types::{
         ChatCompletionMessageToolCall, ChatCompletionRequestAssistantMessageArgs,
@@ -13,17 +14,16 @@ use async_openai::{
         ChatCompletionRequestUserMessageContentPart, ChatCompletionStreamOptions,
         CreateChatCompletionRequest, CreateChatCompletionRequestArgs,
     },
-    Client,
 };
 use async_trait::async_trait;
 use futures::{Stream, StreamExt};
 
 use crate::schemas::convert::{LangchainIntoOpenAI, TryLangchainIntoOpenAI};
 use crate::{
-    language_models::{llm::LLM, options::CallOptions, GenerateResult, LLMError, TokenUsage},
+    language_models::{GenerateResult, LLMError, TokenUsage, llm::LLM, options::CallOptions},
     schemas::{
-        messages::{Message, MessageType},
         StreamData,
+        messages::{Message, MessageType},
     },
 };
 

--- a/crates/langchainx-llm/src/qwen/client.rs
+++ b/crates/langchainx-llm/src/qwen/client.rs
@@ -1,6 +1,6 @@
 use crate::{
-    language_models::{llm::LLM, options::CallOptions, GenerateResult, LLMError, TokenUsage},
     QwenError,
+    language_models::{GenerateResult, LLMError, TokenUsage, llm::LLM, options::CallOptions},
     schemas::{Message, StreamData},
 };
 use async_trait::async_trait;
@@ -262,7 +262,7 @@ impl Qwen {
                     None => {
                         return Err(LLMError::ContentNotFound(
                             "No content returned from API".to_string(),
-                        ))
+                        ));
                     }
                 };
 

--- a/crates/langchainx-llm/src/schemas/tools_openai_like.rs
+++ b/crates/langchainx-llm/src/schemas/tools_openai_like.rs
@@ -45,8 +45,6 @@ impl FunctionDefinition {
             parameters,
         }
     }
-
-
 }
 
 impl TryOpenAiFromLangchain<FunctionDefinition> for ChatCompletionTool {

--- a/crates/langchainx-memory/src/lib.rs
+++ b/crates/langchainx-memory/src/lib.rs
@@ -1,5 +1,5 @@
-pub use langchainx_core::schemas;
 pub use langchainx_core::language_models;
+pub use langchainx_core::schemas;
 
 mod dummy_memory;
 mod simple_memory;

--- a/crates/langchainx-prompt/src/lib.rs
+++ b/crates/langchainx-prompt/src/lib.rs
@@ -1,5 +1,5 @@
-pub use langchainx_core::schemas;
 pub use langchainx_core::language_models;
+pub use langchainx_core::schemas;
 
 pub mod prompt;
 pub use prompt::*;

--- a/crates/langchainx-prompt/src/prompt/chat.rs
+++ b/crates/langchainx-prompt/src/prompt/chat.rs
@@ -297,7 +297,7 @@ macro_rules! message_formatter {
 mod tests {
     use crate::{
         message_formatter,
-        prompt::{chat::AIMessagePromptTemplate, FormatPrompter},
+        prompt::{FormatPrompter, chat::AIMessagePromptTemplate},
         prompt_args,
         schemas::messages::Message,
         template_fstring,

--- a/examples/agent.rs
+++ b/examples/agent.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use langchainx::{
     agent::{AgentExecutor, ConversationalAgentBuilder},
-    chain::{options::ChainCallOptions, Chain},
+    chain::{Chain, options::ChainCallOptions},
     llm::openai::OpenAI,
     memory::SimpleMemory,
     prompt_args,

--- a/examples/conversational_chain.rs
+++ b/examples/conversational_chain.rs
@@ -1,8 +1,8 @@
-use std::io::{stdout, Write};
+use std::io::{Write, stdout};
 
 use futures_util::StreamExt;
 use langchainx::{
-    chain::{builder::ConversationalChainBuilder, Chain},
+    chain::{Chain, builder::ConversationalChainBuilder},
     // fmt_message, fmt_template,
     llm::openai::OpenAI,
     memory::SimpleMemory,

--- a/examples/conversational_retriever_chain_with_vector_store.rs
+++ b/examples/conversational_retriever_chain_with_vector_store.rs
@@ -11,7 +11,7 @@ use langchainx::{
     memory::SimpleMemory,
     prompt_args,
     schemas::Document,
-    vectorstore::{pgvector::StoreBuilder, Retriever, VectorStore},
+    vectorstore::{Retriever, VectorStore, pgvector::StoreBuilder},
 };
 
 #[cfg(feature = "postgres")]

--- a/examples/git_commits.rs
+++ b/examples/git_commits.rs
@@ -11,7 +11,7 @@ use langchainx::{
     document_loaders::GitCommitLoader,
     document_loaders::Loader,
     embedding::openai::OpenAiEmbedder,
-    vectorstore::{sqlite_vss::StoreBuilder, VecStoreOptions, VectorStore},
+    vectorstore::{VecStoreOptions, VectorStore, sqlite_vss::StoreBuilder},
 };
 #[cfg(feature = "sqlite-vss")]
 use std::io::Write;

--- a/examples/llm_alibaba_qwen.rs
+++ b/examples/llm_alibaba_qwen.rs
@@ -8,9 +8,7 @@ async fn main() {
     // Requires QWEN_API_KEY environment variable to be set
     let api_key =
         std::env::var("QWEN_API_KEY").expect("QWEN_API_KEY environment variable must be set");
-    let qwen = Qwen::new()
-        .with_api_key(api_key)
-        .with_model("qwen-turbo"); // Can use enum: QwenModel::QwenTurbo.to_string()
+    let qwen = Qwen::new().with_api_key(api_key).with_model("qwen-turbo"); // Can use enum: QwenModel::QwenTurbo.to_string()
 
     // Generate a response
     let response = qwen

--- a/examples/open_ai_tools_agent.rs
+++ b/examples/open_ai_tools_agent.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use langchainx::{
     agent::{AgentExecutor, OpenAiToolAgentBuilder},
-    chain::{options::ChainCallOptions, Chain},
+    chain::{Chain, options::ChainCallOptions},
     llm::openai::OpenAI,
     memory::SimpleMemory,
     prompt_args,

--- a/examples/sql_chain.rs
+++ b/examples/sql_chain.rs
@@ -2,9 +2,9 @@
 
 #[cfg(feature = "postgres")]
 use langchainx::{
-    chain::{options::ChainCallOptions, Chain, SQLDatabaseChainBuilder},
+    chain::{Chain, SQLDatabaseChainBuilder, options::ChainCallOptions},
     llm::openai::OpenAI,
-    tools::{postgres::PostgreSQLEngine, SQLDatabaseBuilder},
+    tools::{SQLDatabaseBuilder, postgres::PostgreSQLEngine},
 };
 
 #[cfg(feature = "postgres")]

--- a/examples/vector_store_opensearch.rs
+++ b/examples/vector_store_opensearch.rs
@@ -106,11 +106,11 @@ async fn add_documents_to_index(store: &Store) -> Result<Vec<String>, Box<dyn Er
     .with_metadata(HashMap::from([("source".to_string(), json!("cli"))]));
 
     let doc2 = Document::new(
-        "langchaingo is a port of the langchain python library to go language and was written in 2023."
+        "langchaingo is a port of the langchain python library to go language and was written in 2023.",
     );
 
     let doc3 = Document::new(
-        "Capital of United States of America (USA) is Washington D.C. and the capital of France is Paris."
+        "Capital of United States of America (USA) is Washington D.C. and the capital of France is Paris.",
     );
 
     let doc4 = Document::new("Capital of France is Paris.");

--- a/examples/vector_store_postgres.rs
+++ b/examples/vector_store_postgres.rs
@@ -7,7 +7,7 @@ use langchainx::{
     embedding::openai::openai_embedder::OpenAiEmbedder,
     schemas::Document,
     similarity_search,
-    vectorstore::{pgvector::StoreBuilder, VectorStore},
+    vectorstore::{VectorStore, pgvector::StoreBuilder},
 };
 #[cfg(feature = "postgres")]
 use std::io::Write;

--- a/examples/vector_store_qdrant.rs
+++ b/examples/vector_store_qdrant.rs
@@ -4,8 +4,8 @@
 use langchainx::{
     embedding::openai::openai_embedder::OpenAiEmbedder,
     schemas::Document,
-    vectorstore::qdrant::{Qdrant, StoreBuilder},
     vectorstore::VectorStore,
+    vectorstore::qdrant::{Qdrant, StoreBuilder},
 };
 #[cfg(feature = "qdrant")]
 use std::io::Write;
@@ -38,10 +38,10 @@ async fn main() {
         "langchainx is a port of the langchain python library to rust and was written in 2024.",
     );
     let doc2 = Document::new(
-        "langchaingo is a port of the langchain python library to go language and was written in 2023."
+        "langchaingo is a port of the langchain python library to go language and was written in 2023.",
     );
     let doc3 = Document::new(
-        "Capital of United States of America (USA) is Washington D.C. and the capital of France is Paris."
+        "Capital of United States of America (USA) is Washington D.C. and the capital of France is Paris.",
     );
     let doc4 = Document::new("Capital of France is Paris.");
 

--- a/examples/vector_store_sqlite_vec.rs
+++ b/examples/vector_store_sqlite_vec.rs
@@ -6,7 +6,7 @@
 use langchainx::{
     embedding::openai::openai_embedder::OpenAiEmbedder,
     schemas::Document,
-    vectorstore::{sqlite_vec::StoreBuilder, VecStoreOptions, VectorStore},
+    vectorstore::{VecStoreOptions, VectorStore, sqlite_vec::StoreBuilder},
 };
 
 #[cfg(feature = "sqlite-vec")]
@@ -38,10 +38,10 @@ async fn main() {
         "langchainx is a port of the langchain python library to rust and was written in 2024.",
     );
     let doc2 = Document::new(
-        "langchaingo is a port of the langchain python library to go language and was written in 2023."
+        "langchaingo is a port of the langchain python library to go language and was written in 2023.",
     );
     let doc3 = Document::new(
-        "Capital of United States of America (USA) is Washington D.C. and the capital of France is Paris."
+        "Capital of United States of America (USA) is Washington D.C. and the capital of France is Paris.",
     );
     let doc4 = Document::new("Capital of France is Paris.");
 

--- a/examples/vector_store_sqlite_vss.rs
+++ b/examples/vector_store_sqlite_vss.rs
@@ -8,7 +8,7 @@
 use langchainx::{
     embedding::openai::openai_embedder::OpenAiEmbedder,
     schemas::Document,
-    vectorstore::{sqlite_vss::StoreBuilder, VecStoreOptions, VectorStore},
+    vectorstore::{VecStoreOptions, VectorStore, sqlite_vss::StoreBuilder},
 };
 #[cfg(feature = "sqlite-vss")]
 use std::io::Write;
@@ -39,10 +39,10 @@ async fn main() {
         "langchainx is a port of the langchain python library to rust and was written in 2024.",
     );
     let doc2 = Document::new(
-        "langchaingo is a port of the langchain python library to go language and was written in 2023."
+        "langchaingo is a port of the langchain python library to go language and was written in 2023.",
     );
     let doc3 = Document::new(
-        "Capital of United States of America (USA) is Washington D.C. and the capital of France is Paris."
+        "Capital of United States of America (USA) is Washington D.C. and the capital of France is Paris.",
     );
     let doc4 = Document::new("Capital of France is Paris.");
 

--- a/src/agent/chat/builder.rs
+++ b/src/agent/chat/builder.rs
@@ -8,9 +8,9 @@ use crate::{
 };
 
 use super::{
+    ConversationalAgent,
     output_parser::ChatOutputParser,
     prompt::{PREFIX, SUFFIX},
-    ConversationalAgent,
 };
 
 pub struct ConversationalAgentBuilder {

--- a/src/agent/chat/chat_agent.rs
+++ b/src/agent/chat/chat_agent.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use serde_json::json;
 
 use crate::{
-    agent::{agent::Agent, chat::prompt::FORMAT_INSTRUCTIONS, AgentError},
+    agent::{AgentError, agent::Agent, chat::prompt::FORMAT_INSTRUCTIONS},
     chain::chain_trait::Chain,
     message_formatter,
     prompt::{

--- a/src/agent/executor.rs
+++ b/src/agent/executor.rs
@@ -4,10 +4,10 @@ use async_trait::async_trait;
 use serde_json::json;
 use tokio::sync::Mutex;
 
-use super::{agent::Agent, AgentError};
+use super::{AgentError, agent::Agent};
 use crate::schemas::{LogTools, Message};
 use crate::{
-    chain::{chain_trait::Chain, ChainError},
+    chain::{ChainError, chain_trait::Chain},
     language_models::GenerateResult,
     memory::SimpleMemory,
     prompt::PromptArgs,

--- a/src/agent/open_ai_tools/agent.rs
+++ b/src/agent/open_ai_tools/agent.rs
@@ -10,9 +10,9 @@ use crate::{
     fmt_message, fmt_placeholder, fmt_template, message_formatter,
     prompt::{HumanMessagePromptTemplate, MessageFormatterStruct, PromptArgs},
     schemas::{
+        FunctionCallResponse,
         agent::{AgentAction, AgentEvent, AgentFinish, LogTools},
         messages::Message,
-        FunctionCallResponse,
     },
     template_jinja2,
     tools::Tool,

--- a/src/agent/open_ai_tools/builder.rs
+++ b/src/agent/open_ai_tools/builder.rs
@@ -2,13 +2,13 @@ use std::sync::Arc;
 
 use crate::{
     agent::AgentError,
-    chain::{options::ChainCallOptions, LLMChainBuilder},
+    chain::{LLMChainBuilder, options::ChainCallOptions},
     language_models::{llm::LLM, options::CallOptions},
     schemas::FunctionDefinition,
     tools::Tool,
 };
 
-use super::{prompt::PREFIX, OpenAiToolAgent};
+use super::{OpenAiToolAgent, prompt::PREFIX};
 
 pub struct OpenAiToolAgentBuilder {
     tools: Option<Vec<Arc<dyn Tool>>>,

--- a/src/chain/chain_trait.rs
+++ b/src/chain/chain_trait.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, pin::Pin};
 
 use async_trait::async_trait;
 use futures::Stream;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::{language_models::GenerateResult, prompt::PromptArgs, schemas::StreamData};
 

--- a/src/chain/conversational/builder.rs
+++ b/src/chain/conversational/builder.rs
@@ -4,7 +4,7 @@ use tokio::sync::Mutex;
 
 use crate::{
     chain::{
-        llm_chain::LLMChainBuilder, options::ChainCallOptions, ChainError, DEFAULT_OUTPUT_KEY,
+        ChainError, DEFAULT_OUTPUT_KEY, llm_chain::LLMChainBuilder, options::ChainCallOptions,
     },
     language_models::llm::{IntoArcLLM, LLM},
     memory::SimpleMemory,
@@ -14,7 +14,7 @@ use crate::{
     template_fstring,
 };
 
-use super::{prompt::DEFAULT_TEMPLATE, ConversationalChain, DEFAULT_INPUT_VARIABLE};
+use super::{ConversationalChain, DEFAULT_INPUT_VARIABLE, prompt::DEFAULT_TEMPLATE};
 
 pub struct ConversationalChainBuilder {
     llm: Option<Arc<dyn LLM>>,

--- a/src/chain/conversational/mod.rs
+++ b/src/chain/conversational/mod.rs
@@ -3,19 +3,19 @@ use std::{pin::Pin, sync::Arc};
 use async_stream::stream;
 use async_trait::async_trait;
 use futures::Stream;
-use futures_util::{pin_mut, StreamExt};
+use futures_util::{StreamExt, pin_mut};
 use tokio::sync::Mutex;
 
 use crate::{
     language_models::GenerateResult,
     prompt::PromptArgs,
     prompt_args,
-    schemas::{memory::BaseMemory, messages::Message, StreamData},
+    schemas::{StreamData, memory::BaseMemory, messages::Message},
 };
 
 const DEFAULT_INPUT_VARIABLE: &str = "input";
 
-use super::{chain_trait::Chain, llm_chain::LLMChain, ChainError};
+use super::{ChainError, chain_trait::Chain, llm_chain::LLMChain};
 
 pub mod builder;
 mod prompt;
@@ -136,7 +136,7 @@ impl Chain for ConversationalChain {
 #[cfg(test)]
 mod tests {
     use crate::{
-        chain::{conversational::builder::ConversationalChainBuilder, Chain},
+        chain::{Chain, conversational::builder::ConversationalChainBuilder},
         prompt_args,
         test_utils::FakeLLM,
     };

--- a/src/chain/conversational_retrieval_qa/builder.rs
+++ b/src/chain/conversational_retrieval_qa/builder.rs
@@ -3,7 +3,7 @@ use tokio::sync::Mutex;
 
 use crate::{
     chain::{
-        Chain, ChainError, CondenseQuestionGeneratorChain, StuffDocumentBuilder, DEFAULT_OUTPUT_KEY,
+        Chain, ChainError, CondenseQuestionGeneratorChain, DEFAULT_OUTPUT_KEY, StuffDocumentBuilder,
     },
     language_models::llm::{IntoArcLLM, LLM},
     memory::SimpleMemory,

--- a/src/chain/conversational_retrieval_qa/conversational_retrieval_qa.rs
+++ b/src/chain/conversational_retrieval_qa/conversational_retrieval_qa.rs
@@ -1,15 +1,15 @@
 use futures::Stream;
-use futures_util::{pin_mut, StreamExt};
+use futures_util::{StreamExt, pin_mut};
 use std::{collections::HashMap, pin::Pin, sync::Arc};
 
 use async_stream::stream;
 use async_trait::async_trait;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use tokio::sync::Mutex;
 
 use crate::{
     chain::{
-        Chain, ChainError, CondenseQuestionPromptBuilder, StuffQAPromptBuilder, DEFAULT_RESULT_KEY,
+        Chain, ChainError, CondenseQuestionPromptBuilder, DEFAULT_RESULT_KEY, StuffQAPromptBuilder,
     },
     language_models::{GenerateResult, TokenUsage},
     prompt::PromptArgs,

--- a/src/chain/llm_chain.rs
+++ b/src/chain/llm_chain.rs
@@ -7,15 +7,15 @@ use futures_util::TryStreamExt;
 
 use crate::{
     language_models::{
-        llm::{IntoArcLLM, LLM},
         GenerateResult,
+        llm::{IntoArcLLM, LLM},
     },
     output_parsers::{OutputParser, SimpleParser},
     prompt::{FormatPrompter, PromptArgs},
     schemas::StreamData,
 };
 
-use super::{chain_trait::Chain, options::ChainCallOptions, ChainError};
+use super::{ChainError, chain_trait::Chain, options::ChainCallOptions};
 
 pub struct LLMChainBuilder {
     prompt: Option<Box<dyn FormatPrompter>>,

--- a/src/chain/question_answering.rs
+++ b/src/chain/question_answering.rs
@@ -4,15 +4,15 @@ use async_trait::async_trait;
 use futures::Stream;
 
 use crate::{
-    language_models::{llm::IntoArcLLM, GenerateResult},
+    language_models::{GenerateResult, llm::IntoArcLLM},
     prompt::PromptArgs,
     prompt_args,
-    schemas::{messages::Message, Document, StreamData},
+    schemas::{Document, StreamData, messages::Message},
     template_jinja2,
 };
 
 use super::{
-    options::ChainCallOptions, Chain, ChainError, LLMChain, LLMChainBuilder, StuffDocument,
+    Chain, ChainError, LLMChain, LLMChainBuilder, StuffDocument, options::ChainCallOptions,
 };
 
 const DEFAULTCONDENSEQUESTIONTEMPLATE: &str = r#"Given the following conversation and a follow up question, rephrase the follow up question to be a standalone question, in its original language.
@@ -66,7 +66,7 @@ impl CondenseQuestionGeneratorChain {
             .prompt(condense_question_prompt_template)
             .build()
             .unwrap(); //Its safe to unwrap here because we are sure that the prompt and the LLM are
-                       //set.
+        //set.
         Self { chain }
     }
 

--- a/src/chain/sequential/chain.rs
+++ b/src/chain/sequential/chain.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use async_trait::async_trait;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::{
     chain::{Chain, ChainError, DEFAULT_OUTPUT_KEY, DEFAULT_RESULT_KEY},

--- a/src/chain/sql_datbase/builder.rs
+++ b/src/chain/sql_datbase/builder.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::{
     chain::{
-        llm_chain::LLMChainBuilder, options::ChainCallOptions, ChainError, DEFAULT_OUTPUT_KEY,
+        ChainError, DEFAULT_OUTPUT_KEY, llm_chain::LLMChainBuilder, options::ChainCallOptions,
     },
     language_models::llm::{IntoArcLLM, LLM},
     output_parsers::OutputParser,
@@ -12,9 +12,9 @@ use crate::{
 };
 
 use super::{
+    STOP_WORD,
     chain::SQLDatabaseChain,
     prompt::{DEFAULT_SQLSUFFIX, DEFAULT_SQLTEMPLATE},
-    STOP_WORD,
 };
 
 pub struct SQLDatabaseChainBuilder {

--- a/src/chain/sql_datbase/chain.rs
+++ b/src/chain/sql_datbase/chain.rs
@@ -5,7 +5,7 @@ use futures::Stream;
 use serde_json::Value;
 
 use crate::{
-    chain::{chain_trait::Chain, llm_chain::LLMChain, ChainError},
+    chain::{ChainError, chain_trait::Chain, llm_chain::LLMChain},
     language_models::{GenerateResult, TokenUsage},
     prompt::PromptArgs,
     prompt_args,

--- a/src/chain/stuff_documents/builder.rs
+++ b/src/chain/stuff_documents/builder.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::{
-    chain::{options::ChainCallOptions, ChainError, LLMChainBuilder},
+    chain::{ChainError, LLMChainBuilder, options::ChainCallOptions},
     language_models::llm::{IntoArcLLM, LLM},
     output_parsers::OutputParser,
     prompt::FormatPrompter,

--- a/src/chain/stuff_documents/chain.rs
+++ b/src/chain/stuff_documents/chain.rs
@@ -6,11 +6,11 @@ use serde_json::Value;
 
 use crate::{
     chain::{
-        load_stuff_qa, options::ChainCallOptions, Chain, ChainError, LLMChain, StuffQAPromptBuilder,
+        Chain, ChainError, LLMChain, StuffQAPromptBuilder, load_stuff_qa, options::ChainCallOptions,
     },
     language_models::{
-        llm::{IntoArcLLM, LLM},
         GenerateResult,
+        llm::{IntoArcLLM, LLM},
     },
     prompt::PromptArgs,
     schemas::{Document, StreamData},

--- a/src/document_loaders/csv_loader/csv_loader.rs
+++ b/src/document_loaders/csv_loader/csv_loader.rs
@@ -1,4 +1,4 @@
-use crate::document_loaders::{process_doc_stream, LoaderError};
+use crate::document_loaders::{LoaderError, process_doc_stream};
 use crate::{document_loaders::Loader, schemas::Document, text_splitter::TextSplitter};
 use async_stream::stream;
 use async_trait::async_trait;

--- a/src/document_loaders/document_loader.rs
+++ b/src/document_loaders/document_loader.rs
@@ -3,7 +3,7 @@ use std::pin::Pin;
 use async_stream::stream;
 use async_trait::async_trait;
 use futures::Stream;
-use futures_util::{pin_mut, StreamExt};
+use futures_util::{StreamExt, pin_mut};
 
 use crate::{schemas::Document, text_splitter::TextSplitter};
 

--- a/src/document_loaders/git_commit_loader/git_commit_loader.rs
+++ b/src/document_loaders/git_commit_loader/git_commit_loader.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::pin::Pin;
 
-use crate::document_loaders::{process_doc_stream, LoaderError};
+use crate::document_loaders::{LoaderError, process_doc_stream};
 use crate::{document_loaders::Loader, schemas::Document, text_splitter::TextSplitter};
 use async_trait::async_trait;
 use futures::Stream;

--- a/src/document_loaders/html_loader/html_loader.rs
+++ b/src/document_loaders/html_loader/html_loader.rs
@@ -7,12 +7,12 @@ use std::{
 };
 
 use async_trait::async_trait;
-use futures::{stream, Stream};
+use futures::{Stream, stream};
 use serde_json::Value;
 use url::Url;
 
 use crate::{
-    document_loaders::{process_doc_stream, Loader, LoaderError},
+    document_loaders::{Loader, LoaderError, process_doc_stream},
     schemas::Document,
     text_splitter::TextSplitter,
 };

--- a/src/document_loaders/html_to_markdown_loader/html_to_markdown_loader.rs
+++ b/src/document_loaders/html_to_markdown_loader/html_to_markdown_loader.rs
@@ -7,14 +7,14 @@ use std::{
 };
 
 use async_trait::async_trait;
-use futures::{stream, Stream};
+use futures::{Stream, stream};
 use serde_json::Value;
 use url::Url;
 
 pub use htmd::{HtmlToMarkdown, HtmlToMarkdownBuilder};
 
 use crate::{
-    document_loaders::{process_doc_stream, Loader, LoaderError},
+    document_loaders::{Loader, LoaderError, process_doc_stream},
     schemas::Document,
     text_splitter::TextSplitter,
 };

--- a/src/document_loaders/json_loader/json_loader.rs
+++ b/src/document_loaders/json_loader/json_loader.rs
@@ -1,4 +1,4 @@
-use crate::document_loaders::{process_doc_stream, LoaderError};
+use crate::document_loaders::{LoaderError, process_doc_stream};
 use crate::{document_loaders::Loader, schemas::Document, text_splitter::TextSplitter};
 use async_stream::stream;
 use async_trait::async_trait;
@@ -186,9 +186,9 @@ fn doc_from_value(value: Value, content_key: Option<&str>) -> Result<Document, L
             let mut obj = match value {
                 Value::Object(m) => m,
                 other => {
-                    return Err(LoaderError::OtherError(
-                        format!("expected JSON object, got {other}"),
-                    ));
+                    return Err(LoaderError::OtherError(format!(
+                        "expected JSON object, got {other}"
+                    )));
                 }
             };
             let content_val = obj.remove(key).unwrap_or(Value::Null);
@@ -234,7 +234,8 @@ mod tests {
     // Test 2: JSON array, content_key set → that field as page_content, rest as metadata
     #[tokio::test]
     async fn test_json_array_with_content_key() {
-        let input = r#"[{"text":"hello world","source":"a.txt"},{"text":"foo bar","source":"b.txt"}]"#;
+        let input =
+            r#"[{"text":"hello world","source":"a.txt"},{"text":"foo bar","source":"b.txt"}]"#;
         let loader = JsonLoader::from_string(input).with_content_key("text");
         let docs: Vec<_> = loader
             .load()

--- a/src/document_loaders/markdown_loader/markdown_loader.rs
+++ b/src/document_loaders/markdown_loader/markdown_loader.rs
@@ -1,10 +1,10 @@
 use std::pin::Pin;
 
 use async_trait::async_trait;
-use futures::{stream, Stream};
+use futures::{Stream, stream};
 
 use crate::{
-    document_loaders::{process_doc_stream, Loader, LoaderError},
+    document_loaders::{Loader, LoaderError, process_doc_stream},
     schemas::Document,
     text_splitter::TextSplitter,
 };
@@ -63,8 +63,7 @@ impl Loader for MarkdownLoader {
         let (meta_pairs, body) = parse_frontmatter(&self.content);
         let mut doc = Document::new(body);
         for (k, v) in meta_pairs {
-            doc.metadata
-                .insert(k, serde_json::Value::String(v));
+            doc.metadata.insert(k, serde_json::Value::String(v));
         }
         let stream = stream::iter(vec![Ok(doc)]);
         Ok(Box::pin(stream))

--- a/src/document_loaders/pandoc_loader/pandoc_loader.rs
+++ b/src/document_loaders/pandoc_loader/pandoc_loader.rs
@@ -1,7 +1,7 @@
 use std::{fmt, path::Path, pin::Pin, process::Stdio};
 
 use async_trait::async_trait;
-use futures_util::{stream, Stream};
+use futures_util::{Stream, stream};
 use tokio::{
     fs::File,
     io::{AsyncRead, AsyncWriteExt, BufReader},
@@ -9,7 +9,7 @@ use tokio::{
 };
 
 use crate::{
-    document_loaders::{process_doc_stream, Loader, LoaderError},
+    document_loaders::{Loader, LoaderError, process_doc_stream},
     schemas::Document,
     text_splitter::TextSplitter,
 };

--- a/src/document_loaders/pdf_loader/lo_loader.rs
+++ b/src/document_loaders/pdf_loader/lo_loader.rs
@@ -6,7 +6,7 @@ use futures::Stream;
 use serde_json::Value;
 
 use crate::{
-    document_loaders::{process_doc_stream, Loader, LoaderError},
+    document_loaders::{Loader, LoaderError, process_doc_stream},
     schemas::Document,
     text_splitter::TextSplitter,
 };

--- a/src/document_loaders/pdf_loader/pdf_extract_loader.rs
+++ b/src/document_loaders/pdf_loader/pdf_extract_loader.rs
@@ -3,10 +3,10 @@ use std::{io::Read, path::Path, pin::Pin};
 use async_stream::stream;
 use async_trait::async_trait;
 use futures::Stream;
-use pdf_extract::{output_doc, PlainTextOutput};
+use pdf_extract::{PlainTextOutput, output_doc};
 
 use crate::{
-    document_loaders::{process_doc_stream, Loader, LoaderError},
+    document_loaders::{Loader, LoaderError, process_doc_stream},
     schemas::Document,
     text_splitter::TextSplitter,
 };
@@ -102,7 +102,10 @@ mod tests {
             .collect::<Vec<_>>()
             .await;
 
-        assert_eq!(&docs[0].page_content[..100], "\n\nSample PDF Document\n\nRobert Maron\nGrzegorz Grudzi´nski\n\nFebruary 20, 1999\n\n2\n\nContents\n\n1 Templat");
+        assert_eq!(
+            &docs[0].page_content[..100],
+            "\n\nSample PDF Document\n\nRobert Maron\nGrzegorz Grudzi´nski\n\nFebruary 20, 1999\n\n2\n\nContents\n\n1 Templat"
+        );
         assert_eq!(docs.len(), 1);
     }
 
@@ -124,7 +127,10 @@ mod tests {
             .collect::<Vec<_>>()
             .await;
 
-        assert_eq!(&docs[0].page_content[..100], "\n\nSample PDF Document\n\nRobert Maron\nGrzegorz Grudzi´nski\n\nFebruary 20, 1999\n\n2\n\nContents\n\n1 Templat");
+        assert_eq!(
+            &docs[0].page_content[..100],
+            "\n\nSample PDF Document\n\nRobert Maron\nGrzegorz Grudzi´nski\n\nFebruary 20, 1999\n\n2\n\nContents\n\n1 Templat"
+        );
         assert_eq!(docs.len(), 1);
     }
 }

--- a/src/document_loaders/rss_loader/rss_loader.rs
+++ b/src/document_loaders/rss_loader/rss_loader.rs
@@ -5,11 +5,11 @@ use std::{
 };
 
 use async_trait::async_trait;
-use futures::{stream, Stream};
+use futures::{Stream, stream};
 use serde_json::Value;
 
 use crate::{
-    document_loaders::{process_doc_stream, Loader, LoaderError},
+    document_loaders::{Loader, LoaderError, process_doc_stream},
     schemas::Document,
     text_splitter::TextSplitter,
 };
@@ -66,10 +66,7 @@ impl<R: Read + BufRead + Send + Sync + 'static> Loader for RssLoader<R> {
                             metadata.insert("link".to_string(), Value::String(l.to_string()));
                         }
                         if let Some(d) = item.pub_date() {
-                            metadata.insert(
-                                "pub_date".to_string(),
-                                Value::String(d.to_string()),
-                            );
+                            metadata.insert("pub_date".to_string(), Value::String(d.to_string()));
                         }
                         if let Some(a) = item.author() {
                             metadata.insert("author".to_string(), Value::String(a.to_string()));

--- a/src/document_loaders/sitemap_loader/sitemap_loader.rs
+++ b/src/document_loaders/sitemap_loader/sitemap_loader.rs
@@ -5,7 +5,7 @@ use futures::Stream;
 use futures_util::StreamExt;
 
 use crate::{
-    document_loaders::{process_doc_stream, HtmlLoader, Loader, LoaderError},
+    document_loaders::{HtmlLoader, Loader, LoaderError, process_doc_stream},
     schemas::Document,
     text_splitter::TextSplitter,
 };
@@ -49,8 +49,8 @@ impl SitemapLoader {
     }
 
     fn extract_locs(xml: &str, tag: &str) -> Vec<String> {
-        use quick_xml::events::Event;
         use quick_xml::Reader;
+        use quick_xml::events::Event;
 
         let mut reader = Reader::from_str(xml);
         reader.config_mut().trim_text(true);
@@ -117,10 +117,8 @@ impl SitemapLoader {
                 Err(_) => continue,
             };
 
-            let mut page_docs: Vec<Document> = stream
-                .filter_map(|r| async move { r.ok() })
-                .collect()
-                .await;
+            let mut page_docs: Vec<Document> =
+                stream.filter_map(|r| async move { r.ok() }).collect().await;
 
             // Ensure source metadata is set to the loc URL
             for doc in &mut page_docs {
@@ -169,7 +167,9 @@ mod tests {
     use super::*;
 
     fn html_page(title: &str) -> String {
-        format!("<html><head><title>{title}</title></head><body><p>{title} content</p></body></html>")
+        format!(
+            "<html><head><title>{title}</title></head><body><p>{title} content</p></body></html>"
+        )
     }
 
     #[tokio::test]
@@ -209,8 +209,8 @@ mod tests {
             .create_async()
             .await;
 
-        let loader = SitemapLoader::new(format!("{base}/sitemap.xml"))
-            .with_client(reqwest::Client::new());
+        let loader =
+            SitemapLoader::new(format!("{base}/sitemap.xml")).with_client(reqwest::Client::new());
 
         let docs: Vec<Document> = loader
             .load()
@@ -274,8 +274,8 @@ mod tests {
             .create_async()
             .await;
 
-        let loader = SitemapLoader::new(format!("{base}/sitemap.xml"))
-            .with_client(reqwest::Client::new());
+        let loader =
+            SitemapLoader::new(format!("{base}/sitemap.xml")).with_client(reqwest::Client::new());
 
         let docs: Vec<Document> = loader
             .load()

--- a/src/document_loaders/source_code_loader/source_code_loader.rs
+++ b/src/document_loaders/source_code_loader/source_code_loader.rs
@@ -1,5 +1,5 @@
 use crate::document_loaders::{
-    find_files_with_extension, process_doc_stream, DirLoaderOptions, LoaderError,
+    DirLoaderOptions, LoaderError, find_files_with_extension, process_doc_stream,
 };
 use crate::{document_loaders::Loader, schemas::Document, text_splitter::TextSplitter};
 use async_stream::stream;
@@ -10,7 +10,7 @@ use std::fs::File;
 use std::io::Read;
 use std::pin::Pin;
 
-use super::{get_language_by_filename, LanguageParser, LanguageParserOptions};
+use super::{LanguageParser, LanguageParserOptions, get_language_by_filename};
 
 #[derive(Debug, Clone)]
 pub struct SourceCodeLoader {

--- a/src/document_loaders/text_loader/text_loader.rs
+++ b/src/document_loaders/text_loader/text_loader.rs
@@ -1,10 +1,10 @@
 use std::pin::Pin;
 
 use async_trait::async_trait;
-use futures::{stream, Stream};
+use futures::{Stream, stream};
 
 use crate::{
-    document_loaders::{process_doc_stream, Loader, LoaderError},
+    document_loaders::{Loader, LoaderError, process_doc_stream},
     schemas::Document,
     text_splitter::TextSplitter,
 };

--- a/src/embedding/mistralai/mistralai_embedder.rs
+++ b/src/embedding/mistralai/mistralai_embedder.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::embedding::{embedder_trait::Embedder, EmbedderError};
+use crate::embedding::{EmbedderError, embedder_trait::Embedder};
 use async_trait::async_trait;
 use mistralai_client::v1::{client::Client, constants::EmbedModel};
 

--- a/src/embedding/ollama/ollama_embedder.rs
+++ b/src/embedding/ollama/ollama_embedder.rs
@@ -1,13 +1,13 @@
 use std::sync::Arc;
 
-use crate::embedding::{embedder_trait::Embedder, EmbedderError};
+use crate::embedding::{EmbedderError, embedder_trait::Embedder};
 use async_trait::async_trait;
 use ollama_rs::{
+    Ollama as OllamaClient,
     generation::{
         embeddings::request::{EmbeddingsInput, GenerateEmbeddingsRequest},
         options::GenerationOptions,
     },
-    Ollama as OllamaClient,
 };
 
 #[derive(Debug)]

--- a/src/embedding/openai/openai_embedder.rs
+++ b/src/embedding/openai/openai_embedder.rs
@@ -1,10 +1,10 @@
 #![allow(dead_code)]
 
-use crate::embedding::{embedder_trait::Embedder, EmbedderError};
+use crate::embedding::{EmbedderError, embedder_trait::Embedder};
 pub use async_openai::config::{AzureConfig, Config, OpenAIConfig};
 use async_openai::{
-    types::{CreateEmbeddingRequestArgs, EmbeddingInput},
     Client,
+    types::{CreateEmbeddingRequestArgs, EmbeddingInput},
 };
 use async_trait::async_trait;
 

--- a/src/language_models/llm.rs
+++ b/src/language_models/llm.rs
@@ -6,7 +6,7 @@ use futures::Stream;
 
 use crate::schemas::{Message, StreamData};
 
-use super::{options::CallOptions, GenerateResult, LLMError};
+use super::{GenerateResult, LLMError, options::CallOptions};
 
 #[async_trait]
 pub trait LLM: Sync + Send {

--- a/src/llm/claude/client.rs
+++ b/src/llm/claude/client.rs
@@ -1,5 +1,5 @@
 use crate::{
-    language_models::{llm::LLM, options::CallOptions, GenerateResult, LLMError, TokenUsage},
+    language_models::{GenerateResult, LLMError, TokenUsage, llm::LLM, options::CallOptions},
     llm::AnthropicError,
     schemas::{Message, MessageType, StreamData},
 };

--- a/src/llm/deepseek/client.rs
+++ b/src/llm/deepseek/client.rs
@@ -1,5 +1,5 @@
 use crate::{
-    language_models::{llm::LLM, options::CallOptions, GenerateResult, LLMError, TokenUsage},
+    language_models::{GenerateResult, LLMError, TokenUsage, llm::LLM, options::CallOptions},
     llm::DeepseekError,
     schemas::{Message, StreamData},
 };

--- a/src/llm/ollama/client.rs
+++ b/src/llm/ollama/client.rs
@@ -1,17 +1,17 @@
 use crate::{
-    language_models::{llm::LLM, GenerateResult, LLMError, TokenUsage},
+    language_models::{GenerateResult, LLMError, TokenUsage, llm::LLM},
     schemas::{Message, MessageType, StreamData},
 };
 use async_trait::async_trait;
 use futures::Stream;
 use ollama_rs::generation::images::Image;
 pub use ollama_rs::{
+    Ollama as OllamaClient,
     error::OllamaError,
     generation::{
-        chat::{request::ChatMessageRequest, ChatMessage, MessageRole},
+        chat::{ChatMessage, MessageRole, request::ChatMessageRequest},
         options::GenerationOptions,
     },
-    Ollama as OllamaClient,
 };
 use std::pin::Pin;
 use std::sync::Arc;

--- a/src/llm/openai/mod.rs
+++ b/src/llm/openai/mod.rs
@@ -4,6 +4,7 @@ pub use async_openai::config::{AzureConfig, Config, OpenAIConfig};
 
 use async_openai::types::{ChatCompletionToolChoiceOption, ResponseFormat};
 use async_openai::{
+    Client,
     error::OpenAIError,
     types::{
         ChatCompletionMessageToolCall, ChatCompletionRequestAssistantMessageArgs,
@@ -13,17 +14,16 @@ use async_openai::{
         ChatCompletionRequestUserMessageContentPart, ChatCompletionStreamOptions,
         CreateChatCompletionRequest, CreateChatCompletionRequestArgs,
     },
-    Client,
 };
 use async_trait::async_trait;
 use futures::{Stream, StreamExt};
 
 use crate::schemas::convert::{LangchainIntoOpenAI, TryLangchainIntoOpenAI};
 use crate::{
-    language_models::{llm::LLM, options::CallOptions, GenerateResult, LLMError, TokenUsage},
+    language_models::{GenerateResult, LLMError, TokenUsage, llm::LLM, options::CallOptions},
     schemas::{
-        messages::{Message, MessageType},
         StreamData,
+        messages::{Message, MessageType},
     },
 };
 

--- a/src/llm/qwen/client.rs
+++ b/src/llm/qwen/client.rs
@@ -1,5 +1,5 @@
 use crate::{
-    language_models::{llm::LLM, options::CallOptions, GenerateResult, LLMError, TokenUsage},
+    language_models::{GenerateResult, LLMError, TokenUsage, llm::LLM, options::CallOptions},
     llm::QwenError,
     schemas::{Message, StreamData},
 };
@@ -262,7 +262,7 @@ impl Qwen {
                     None => {
                         return Err(LLMError::ContentNotFound(
                             "No content returned from API".to_string(),
-                        ))
+                        ));
                     }
                 };
 

--- a/src/prompt/chat.rs
+++ b/src/prompt/chat.rs
@@ -297,7 +297,7 @@ macro_rules! message_formatter {
 mod tests {
     use crate::{
         message_formatter,
-        prompt::{chat::AIMessagePromptTemplate, FormatPrompter},
+        prompt::{FormatPrompter, chat::AIMessagePromptTemplate},
         prompt_args,
         schemas::messages::Message,
         template_fstring,

--- a/src/semantic_router/index/memory_index.rs
+++ b/src/semantic_router/index/memory_index.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use async_trait::async_trait;
 
-use crate::semantic_router::{utils::cosine_similarity, IndexError, Router};
+use crate::semantic_router::{IndexError, Router, utils::cosine_similarity};
 
 use super::Index;
 

--- a/src/semantic_router/route_layer/builder.rs
+++ b/src/semantic_router/route_layer/builder.rs
@@ -4,7 +4,7 @@ use futures_util::future::try_join_all;
 
 use crate::{
     chain::{LLMChain, LLMChainBuilder},
-    embedding::{openai::OpenAiEmbedder, Embedder},
+    embedding::{Embedder, openai::OpenAiEmbedder},
     language_models::llm::LLM,
     llm::openai::OpenAI,
     prompt::HumanMessagePromptTemplate,

--- a/src/semantic_router/route_layer/error.rs
+++ b/src/semantic_router/route_layer/error.rs
@@ -8,7 +8,9 @@ use serde_json::Error as SerdeJsonError;
 
 #[derive(Error, Debug)]
 pub enum RouterBuilderError {
-    #[error("Invalid Router configuration: at least one of utterances or embedding must be provided, and utterances cannot be an empty vector.")]
+    #[error(
+        "Invalid Router configuration: at least one of utterances or embedding must be provided, and utterances cannot be an empty vector."
+    )]
     InvalidConfiguration,
 }
 

--- a/src/semantic_router/route_layer/route_layer.rs
+++ b/src/semantic_router/route_layer/route_layer.rs
@@ -212,7 +212,7 @@ mod tests {
     use async_trait::async_trait;
 
     use crate::{
-        embedding::{openai::OpenAiEmbedder, EmbedderError},
+        embedding::{EmbedderError, openai::OpenAiEmbedder},
         semantic_router::{MemoryIndex, RouteLayerBuilder},
         test_utils::FakeLLM,
     };

--- a/src/text_splitter/options.rs
+++ b/src/text_splitter/options.rs
@@ -1,5 +1,5 @@
 use text_splitter::ChunkConfig;
-use tiktoken_rs::{get_bpe_from_model, get_bpe_from_tokenizer, tokenizer::Tokenizer, CoreBPE};
+use tiktoken_rs::{CoreBPE, get_bpe_from_model, get_bpe_from_tokenizer, tokenizer::Tokenizer};
 
 use super::TextSplitterError;
 

--- a/src/tools/command_executor/command_executor.rs
+++ b/src/tools/command_executor/command_executor.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::tools::{Tool, ToolError};
 

--- a/src/tools/duckduckgo/duckduckgo_search.rs
+++ b/src/tools/duckduckgo/duckduckgo_search.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use reqwest::Client;
 use scraper::{Html, Selector};
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use url::Url;
 
 use crate::tools::{Tool, ToolError};

--- a/src/tools/sql/postgres/postgres.rs
+++ b/src/tools/sql/postgres/postgres.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use sqlx::{postgres::PgPoolOptions, Column, Pool, Postgres, Row, TypeInfo};
+use sqlx::{Column, Pool, Postgres, Row, TypeInfo, postgres::PgPoolOptions};
 use std::error::Error;
 
 use crate::tools::{Dialect, Engine};

--- a/src/tools/text2speech/openai/client.rs
+++ b/src/tools/text2speech/openai/client.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
-use async_openai::types::CreateSpeechRequestArgs;
 use async_openai::Client;
+use async_openai::types::CreateSpeechRequestArgs;
 pub use async_openai::{
     config::{Config, OpenAIConfig},
     types::{SpeechModel, SpeechResponseFormat, Voice},

--- a/src/tools/tool.rs
+++ b/src/tools/tool.rs
@@ -1,7 +1,7 @@
 use std::string::String;
 
 use async_trait::async_trait;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use super::ToolError;
 

--- a/src/vectorstore/opensearch/opensearch.rs
+++ b/src/vectorstore/opensearch/opensearch.rs
@@ -3,14 +3,14 @@ use opensearch::http::request::JsonBody;
 use opensearch::http::response::Response;
 use opensearch::indices::{IndicesCreateParts, IndicesDeleteParts};
 use opensearch::{BulkParts, SearchParts};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::collections::HashMap;
 use std::sync::Arc;
 
+pub use opensearch::OpenSearch;
 pub use opensearch::auth::Credentials;
 pub use opensearch::cert::CertificateValidation;
 pub use opensearch::http::transport::{SingleNodeConnectionPool, TransportBuilder};
-pub use opensearch::OpenSearch;
 
 use crate::{
     embedding::embedder_trait::Embedder,

--- a/src/vectorstore/pgvector/builder.rs
+++ b/src/vectorstore/pgvector/builder.rs
@@ -1,13 +1,13 @@
 use std::{collections::HashMap, env, error::Error, sync::Arc};
 
-use serde_json::{json, Value};
-use sqlx::{postgres::PgPoolOptions, Pool, Postgres, Row, Transaction};
+use serde_json::{Value, json};
+use sqlx::{Pool, Postgres, Row, Transaction, postgres::PgPoolOptions};
 
 use crate::{embedding::embedder_trait::Embedder, vectorstore::VecStoreOptions};
 
 use super::{
-    HNSWIndex, PgFilter, PgOptions, Store, PG_LOCKID_EXTENSION, PG_LOCK_ID_COLLECTION_TABLE,
-    PG_LOCK_ID_EMBEDDING_TABLE,
+    HNSWIndex, PG_LOCK_ID_COLLECTION_TABLE, PG_LOCK_ID_EMBEDDING_TABLE, PG_LOCKID_EXTENSION,
+    PgFilter, PgOptions, Store,
 };
 
 const DEFAULT_COLLECTION_NAME: &str = "langchain";

--- a/src/vectorstore/pgvector/pgvector.rs
+++ b/src/vectorstore/pgvector/pgvector.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
 use pgvector::Vector;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use sqlx::{Pool, Postgres, Row};
 use uuid::Uuid;
 

--- a/src/vectorstore/qdrant/builder.rs
+++ b/src/vectorstore/qdrant/builder.rs
@@ -1,7 +1,7 @@
 use crate::embedding::Embedder;
 use crate::vectorstore::qdrant::Store;
-use qdrant_client::qdrant::{CreateCollectionBuilder, Distance, Filter, VectorParamsBuilder};
 use qdrant_client::Qdrant;
+use qdrant_client::qdrant::{CreateCollectionBuilder, Distance, Filter, VectorParamsBuilder};
 use std::error::Error;
 use std::sync::Arc;
 

--- a/src/vectorstore/qdrant/qdrant.rs
+++ b/src/vectorstore/qdrant/qdrant.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
-use qdrant_client::qdrant::{Filter, PointStruct, SearchPointsBuilder, UpsertPointsBuilder};
 use qdrant_client::Payload;
-use serde_json::{json, Value};
+use qdrant_client::qdrant::{Filter, PointStruct, SearchPointsBuilder, UpsertPointsBuilder};
+use serde_json::{Value, json};
 use std::sync::Arc;
 
 pub use qdrant_client::Qdrant;
@@ -51,8 +51,7 @@ impl VectorStore for Store {
             });
 
             if let Some(extra_json) = opt.filters.clone() {
-                if let (Value::Object(base_map), Value::Object(extra_map)) =
-                    (&mut base, extra_json)
+                if let (Value::Object(base_map), Value::Object(extra_map)) = (&mut base, extra_json)
                 {
                     base_map.extend(extra_map);
                 }

--- a/src/vectorstore/sqlite_vec/builder.rs
+++ b/src/vectorstore/sqlite_vec/builder.rs
@@ -1,8 +1,8 @@
 use std::{error::Error, str::FromStr, sync::Arc};
 
 use sqlx::{
-    sqlite::{SqliteConnectOptions, SqlitePoolOptions},
     Pool, Sqlite,
+    sqlite::{SqliteConnectOptions, SqlitePoolOptions},
 };
 
 use super::Store;

--- a/src/vectorstore/sqlite_vec/sqlite_vec.rs
+++ b/src/vectorstore/sqlite_vec/sqlite_vec.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use sqlx::{Pool, Row, Sqlite};
 
 use crate::{

--- a/src/vectorstore/sqlite_vss/builder.rs
+++ b/src/vectorstore/sqlite_vss/builder.rs
@@ -1,8 +1,8 @@
 use std::{error::Error, str::FromStr, sync::Arc};
 
 use sqlx::{
-    sqlite::{SqliteConnectOptions, SqlitePoolOptions},
     Pool, Sqlite,
+    sqlite::{SqliteConnectOptions, SqlitePoolOptions},
 };
 
 use super::Store;

--- a/src/vectorstore/sqlite_vss/sqlite_vss.rs
+++ b/src/vectorstore/sqlite_vss/sqlite_vss.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use sqlx::{Pool, Row, Sqlite};
 
 use crate::{

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,8 +1,8 @@
 use std::collections::VecDeque;
 use std::pin::Pin;
 use std::sync::{
-    atomic::{AtomicUsize, Ordering},
     Arc,
+    atomic::{AtomicUsize, Ordering},
 };
 
 use async_trait::async_trait;
@@ -10,8 +10,8 @@ use futures::Stream;
 use tokio::sync::Mutex;
 
 use langchainx::{
-    embedding::{embedder_trait::Embedder, EmbedderError},
-    language_models::{llm::LLM, GenerateResult, LLMError},
+    embedding::{EmbedderError, embedder_trait::Embedder},
+    language_models::{GenerateResult, LLMError, llm::LLM},
     schemas::{Message, StreamData},
 };
 

--- a/tests/e2e_containers.rs
+++ b/tests/e2e_containers.rs
@@ -149,11 +149,11 @@ mod pgvector_tests {
         add_documents,
         schemas::Document,
         similarity_search,
-        vectorstore::{pgvector::StoreBuilder, VectorStore},
+        vectorstore::{VectorStore, pgvector::StoreBuilder},
     };
 
     use crate::common::FakeEmbedder;
-    use crate::{free_port, smolvm_available, wait_for_tcp, SmolvmMachine};
+    use crate::{SmolvmMachine, free_port, smolvm_available, wait_for_tcp};
     use serial_test::serial;
 
     async fn start_pgvector() -> (SmolvmMachine, String) {
@@ -264,12 +264,12 @@ mod qdrant_tests {
         add_documents,
         schemas::Document,
         similarity_search,
-        vectorstore::{qdrant::StoreBuilder, VectorStore},
+        vectorstore::{VectorStore, qdrant::StoreBuilder},
     };
     use qdrant_client::Qdrant;
 
     use crate::common::FakeEmbedder;
-    use crate::{free_port, smolvm_available, wait_for_tcp, SmolvmMachine};
+    use crate::{SmolvmMachine, free_port, smolvm_available, wait_for_tcp};
     use serial_test::serial;
 
     async fn start_qdrant() -> (SmolvmMachine, String) {

--- a/tests/e2e_local_llm.rs
+++ b/tests/e2e_local_llm.rs
@@ -8,7 +8,7 @@
 mod common;
 
 use langchainx::{
-    chain::{conversational::builder::ConversationalChainBuilder, Chain, LLMChainBuilder},
+    chain::{Chain, LLMChainBuilder, conversational::builder::ConversationalChainBuilder},
     embedding::OllamaEmbedder,
     fmt_template,
     llm::ollama::client::Ollama,

--- a/tests/e2e_offline.rs
+++ b/tests/e2e_offline.rs
@@ -6,8 +6,8 @@ mod common;
 
 use langchainx::{
     chain::{
-        conversational::builder::ConversationalChainBuilder, Chain, LLMChainBuilder,
-        SequentialChainBuilder,
+        Chain, LLMChainBuilder, SequentialChainBuilder,
+        conversational::builder::ConversationalChainBuilder,
     },
     fmt_template,
     memory::SimpleMemory,

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "xtask"
+version = "0.1.0"
+edition = "2024"
+publish = false
+license.workspace = true
+
+[[bin]]
+name = "xtask"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "1"
+xshell = "0.2"
+
+[dev-dependencies]
+tempfile = "3"

--- a/xtask/src/bump.rs
+++ b/xtask/src/bump.rs
@@ -1,0 +1,117 @@
+//! bump — bump the workspace version in the root Cargo.toml.
+//!
+//! Usage: cargo xtask bump <patch|minor|major>
+
+use anyhow::{Result, bail};
+use std::fs;
+use std::path::Path;
+
+pub fn bump(root: &Path, level: &str) -> Result<()> {
+    let manifest_path = root.join("Cargo.toml");
+    let content = fs::read_to_string(&manifest_path)?;
+
+    let current = parse_workspace_version(&content).ok_or_else(|| {
+        anyhow::anyhow!("could not find [workspace.package] version in Cargo.toml")
+    })?;
+
+    let (major, minor, patch) = parse_semver(&current)?;
+    let next = match level {
+        "patch" => format!("{major}.{minor}.{}", patch + 1),
+        "minor" => format!("{major}.{}.0", minor + 1),
+        "major" => format!("{}.0.0", major + 1),
+        other => bail!("unknown bump level: {other} (expected patch, minor, or major)"),
+    };
+
+    let updated = content.replacen(
+        &format!("version = \"{current}\""),
+        &format!("version = \"{next}\""),
+        1,
+    );
+
+    if updated == content {
+        bail!("version string not found in Cargo.toml — nothing changed");
+    }
+
+    fs::write(&manifest_path, updated)?;
+    println!("version bumped {current} → {next}");
+    Ok(())
+}
+
+fn parse_workspace_version(content: &str) -> Option<String> {
+    let mut in_workspace_package = false;
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed == "[workspace.package]" {
+            in_workspace_package = true;
+            continue;
+        }
+        if in_workspace_package {
+            if trimmed.starts_with('[') {
+                break;
+            }
+            if let Some(v) = trimmed.strip_prefix("version = \"") {
+                if let Some(v) = v.strip_suffix('"') {
+                    return Some(v.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+fn parse_semver(v: &str) -> Result<(u64, u64, u64)> {
+    let parts: Vec<&str> = v.split('.').collect();
+    if parts.len() != 3 {
+        bail!("version {v:?} is not semver (expected X.Y.Z)");
+    }
+    Ok((parts[0].parse()?, parts[1].parse()?, parts[2].parse()?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn make_toml(tmp: &TempDir, version: &str) -> std::path::PathBuf {
+        let path = tmp.path().join("Cargo.toml");
+        fs::write(&path, format!(
+            "[workspace]\nmembers = []\n\n[workspace.package]\nversion = \"{version}\"\nedition = \"2024\"\n"
+        )).unwrap();
+        tmp.path().to_path_buf()
+    }
+
+    #[test]
+    fn patch_bump() {
+        let tmp = TempDir::new().unwrap();
+        let root = make_toml(&tmp, "0.4.5");
+        bump(&root, "patch").unwrap();
+        let content = fs::read_to_string(root.join("Cargo.toml")).unwrap();
+        assert!(content.contains("version = \"0.4.6\""));
+    }
+
+    #[test]
+    fn minor_bump() {
+        let tmp = TempDir::new().unwrap();
+        let root = make_toml(&tmp, "0.4.5");
+        bump(&root, "minor").unwrap();
+        let content = fs::read_to_string(root.join("Cargo.toml")).unwrap();
+        assert!(content.contains("version = \"0.5.0\""));
+    }
+
+    #[test]
+    fn major_bump() {
+        let tmp = TempDir::new().unwrap();
+        let root = make_toml(&tmp, "0.4.5");
+        bump(&root, "major").unwrap();
+        let content = fs::read_to_string(root.join("Cargo.toml")).unwrap();
+        assert!(content.contains("version = \"1.0.0\""));
+    }
+
+    #[test]
+    fn unknown_level_errors() {
+        let tmp = TempDir::new().unwrap();
+        let root = make_toml(&tmp, "0.4.5");
+        assert!(bump(&root, "bogus").is_err());
+    }
+}

--- a/xtask/src/gates.rs
+++ b/xtask/src/gates.rs
@@ -1,0 +1,45 @@
+//! gates — quality gates that mirror CI steps.
+//!
+//! Each function corresponds to one CI step. `pre_commit` runs the local
+//! subset (fast, no network) that should pass before every commit.
+
+use anyhow::{Context, Result};
+use xshell::{Shell, cmd};
+
+/// `cargo fmt --all -- --check`
+pub fn fmt_check(sh: &Shell) -> Result<()> {
+    cmd!(sh, "cargo fmt --all -- --check")
+        .run()
+        .context("fmt check failed")
+}
+
+/// `cargo clippy --all-features -- -D warnings`
+pub fn clippy(sh: &Shell) -> Result<()> {
+    cmd!(sh, "cargo clippy --all-features -- -D warnings")
+        .run()
+        .context("clippy failed")
+}
+
+/// `cargo build --release --all-features`
+pub fn build(sh: &Shell) -> Result<()> {
+    cmd!(sh, "cargo build --release --all-features")
+        .run()
+        .context("build failed")
+}
+
+/// `cargo test --release --all-features`
+pub fn test(sh: &Shell) -> Result<()> {
+    cmd!(sh, "cargo test --release --all-features")
+        .run()
+        .context("tests failed")
+}
+
+/// Local pre-commit gate: fmt-check + clippy.
+///
+/// Matches the first two steps of CI. Run before committing.
+pub fn pre_commit(sh: &Shell) -> Result<()> {
+    fmt_check(sh)?;
+    clippy(sh)?;
+    eprintln!("pre-commit checks passed");
+    Ok(())
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,52 @@
+//! xtask — workspace dev-tool binary.
+//!
+//! Each module has one clear responsibility. Add new tasks by creating a new
+//! module and wiring it into the `match` below; do NOT grow existing modules
+//! beyond their stated scope.
+//!
+//! | Module   | Responsibility                                         |
+//! |----------|--------------------------------------------------------|
+//! | `gates`  | Quality gates: fmt-check, clippy, build, test          |
+//! | `bump`   | Semver version bump in workspace Cargo.toml            |
+
+use anyhow::{Result, bail};
+use std::{env, path::Path};
+use xshell::Shell;
+
+mod bump;
+mod gates;
+
+fn main() -> Result<()> {
+    let task = env::args().nth(1);
+
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
+    env::set_current_dir(root)?;
+
+    let sh = Shell::new()?;
+    sh.change_dir(root);
+
+    match task.as_deref() {
+        Some("fmt-check") => gates::fmt_check(&sh),
+        Some("clippy") => gates::clippy(&sh),
+        Some("build") => gates::build(&sh),
+        Some("test") => gates::test(&sh),
+        Some("pre-commit") => gates::pre_commit(&sh),
+        Some("bump") => {
+            let level = env::args().nth(2).unwrap_or_else(|| "patch".to_string());
+            bump::bump(root, &level)
+        }
+        Some(other) => bail!("unknown task: {other}"),
+        None => {
+            eprintln!("usage: cargo xtask <task>");
+            eprintln!();
+            eprintln!("tasks:");
+            eprintln!("  fmt-check    cargo fmt --check");
+            eprintln!("  clippy       cargo clippy --all-features");
+            eprintln!("  build        cargo build --release --all-features");
+            eprintln!("  test         cargo test --release --all-features");
+            eprintln!("  pre-commit   fmt-check + clippy (local CI gate)");
+            eprintln!("  bump         bump workspace version (patch|minor|major)");
+            Ok(())
+        }
+    }
+}


### PR DESCRIPTION
Closes #28

## Summary

- `LangChainError` currently lives in `src/errors.rs` as an aggregate type with `#[from]`
  impls over all module-level errors (LLM, Chain, Agent, Prompt, etc.)
- Those module errors all still live in `src/` — not yet extracted crates — so a direct
  move into `langchainx-core` would create circular dependencies
- This PR scopes the work correctly: move `LangChainError` into `langchainx-core` as a
  `String`-variant aggregate, keeping `#[from]` impls in the root crate until all dependent
  modules are extracted

## Plan

- [ ] Add `LangChainError` to `langchainx-core` with opaque string variants
- [ ] Replace `src/errors.rs` `#[from]` impls with `impl From<XError> for LangChainError`
      in root `src/lib.rs`
- [ ] Remove `src/errors.rs`, update `src/lib.rs` re-export to point at core
- [ ] `cargo check --workspace` passes

## Note

Full migration unblocked after #22–#27 extract remaining modules into crates.