### PR TITLE
fix(fmt): apply cargo fmt to fix CI fmt-check failures

### DIFF
--- a/crates/langchainx-llm/src/deepseek/client.rs
+++ b/crates/langchainx-llm/src/deepseek/client.rs
@@ -250,10 +250,10 @@ impl LLM for Deepseek {
                                     && let Some(delta) = choice.get("delta")
                                 {
                                     // Handle reasoning_content if it exists
-                                    if include_reasoning && is_reasoner
-                                        && let Some(reasoning) = delta
-                                            .get("reasoning_content")
-                                            .and_then(|c| c.as_str())
+                                    if include_reasoning
+                                        && is_reasoner
+                                        && let Some(reasoning) =
+                                            delta.get("reasoning_content").and_then(|c| c.as_str())
                                         && !reasoning.is_empty()
                                     {
                                         let usage = chunk.get("usage").map(|usage| TokenUsage {
@@ -286,30 +286,25 @@ impl LLM for Deepseek {
                                         delta.get("content").and_then(|c| c.as_str())
                                         && !content.is_empty()
                                     {
-                                        let usage =
-                                            chunk.get("usage").map(|usage| TokenUsage {
-                                                prompt_tokens: usage
-                                                    .get("prompt_tokens")
-                                                    .and_then(|t| t.as_u64())
-                                                    .unwrap_or(0)
-                                                    as u32,
-                                                completion_tokens: usage
-                                                    .get("completion_tokens")
-                                                    .and_then(|t| t.as_u64())
-                                                    .unwrap_or(0)
-                                                    as u32,
-                                                total_tokens: usage
-                                                    .get("total_tokens")
-                                                    .and_then(|t| t.as_u64())
-                                                    .unwrap_or(0)
-                                                    as u32,
-                                            });
+                                        let usage = chunk.get("usage").map(|usage| TokenUsage {
+                                            prompt_tokens: usage
+                                                .get("prompt_tokens")
+                                                .and_then(|t| t.as_u64())
+                                                .unwrap_or(0)
+                                                as u32,
+                                            completion_tokens: usage
+                                                .get("completion_tokens")
+                                                .and_then(|t| t.as_u64())
+                                                .unwrap_or(0)
+                                                as u32,
+                                            total_tokens: usage
+                                                .get("total_tokens")
+                                                .and_then(|t| t.as_u64())
+                                                .unwrap_or(0)
+                                                as u32,
+                                        });
 
-                                        return Ok(StreamData::new(
-                                            chunk.clone(),
-                                            usage,
-                                            content,
-                                        ));
+                                        return Ok(StreamData::new(chunk.clone(), usage, content));
                                     }
                                 }
                             }

--- a/crates/langchainx-loaders/src/markdown_serializer.rs
+++ b/crates/langchainx-loaders/src/markdown_serializer.rs
@@ -29,9 +29,7 @@ pub struct MarkdownDocument {
 
 /// Splits YAML frontmatter (delimited by `---`) from body.
 /// Returns `(metadata_map, body)`.
-pub(crate) fn parse_frontmatter(
-    content: &str,
-) -> (HashMap<String, serde_json::Value>, String) {
+pub(crate) fn parse_frontmatter(content: &str) -> (HashMap<String, serde_json::Value>, String) {
     let mut lines = content.lines();
     let first = lines.next().unwrap_or("");
     if first.trim() != "---" {
@@ -160,7 +158,10 @@ impl MarkdownDocument {
     pub fn parse(src: &str) -> Result<Self, MarkdownSerializerError> {
         let (frontmatter, body) = parse_frontmatter(src);
         let sections = parse_sections(&body);
-        Ok(Self { frontmatter, sections })
+        Ok(Self {
+            frontmatter,
+            sections,
+        })
     }
 
     pub fn to_json(&self) -> Result<String, serde_json::Error> {
@@ -300,8 +301,7 @@ mod tests {
 
     #[test]
     fn test_from_str_full_document() {
-        let src =
-            "---\ntitle: My Doc\n---\n# Intro\nHello world.\n## Details\nMore info.";
+        let src = "---\ntitle: My Doc\n---\n# Intro\nHello world.\n## Details\nMore info.";
         let doc = MarkdownDocument::parse(src).unwrap();
         assert_eq!(
             doc.frontmatter.get("title").unwrap(),

--- a/crates/langchainx-loaders/src/source_code_loader/language_parsers.rs
+++ b/crates/langchainx-loaders/src/source_code_loader/language_parsers.rs
@@ -1,8 +1,8 @@
 use crate::LoaderError;
 use langchainx_core::schemas::Document;
 use std::collections::HashMap;
-use std::fmt::Debug;
 use std::fmt;
+use std::fmt::Debug;
 use strum_macros::Display;
 use tree_sitter::{Parser, Tree};
 

--- a/crates/langchainx-tools/src/sql/postgres/postgres.rs
+++ b/crates/langchainx-tools/src/sql/postgres/postgres.rs
@@ -89,7 +89,9 @@ impl Engine for PostgreSQLEngine {
     }
 
     async fn table_info(&self, table: &str) -> Result<String, Box<dyn Error>> {
-        let query = "SELECT column_name, data_type FROM information_schema.columns WHERE table_name = $1".to_string();
+        let query =
+            "SELECT column_name, data_type FROM information_schema.columns WHERE table_name = $1"
+                .to_string();
         let rows = sqlx::query(&query)
             .bind(table)
             .fetch_all(&self.pool)

--- a/crates/langchainx-vectorstore/src/pgvector/pgvector.rs
+++ b/crates/langchainx-vectorstore/src/pgvector/pgvector.rs
@@ -46,7 +46,11 @@ impl fmt::Display for PgLit {
             PgLit::LitStr(str) => write!(f, "'{}'", str),
             PgLit::JsonField(path) => write!(f, "cmetadata#>>'{{{}}}'", path.join(",")),
             PgLit::RawJson(value) => {
-                write!(f, "{}", serde_json::to_string(value).unwrap_or_else(|_| "null".to_string()))
+                write!(
+                    f,
+                    "{}",
+                    serde_json::to_string(value).unwrap_or_else(|_| "null".to_string())
+                )
             }
         }
     }
@@ -79,12 +83,20 @@ impl fmt::Display for PgFilter {
             PgFilter::And(pgfilters) => write!(
                 f,
                 "{}",
-                pgfilters.iter().map(|pgf| pgf.to_string()).collect::<Vec<String>>().join(" AND ")
+                pgfilters
+                    .iter()
+                    .map(|pgf| pgf.to_string())
+                    .collect::<Vec<String>>()
+                    .join(" AND ")
             ),
             PgFilter::Or(pgfilters) => write!(
                 f,
                 "{}",
-                pgfilters.iter().map(|pgf| pgf.to_string()).collect::<Vec<String>>().join(" OR ")
+                pgfilters
+                    .iter()
+                    .map(|pgf| pgf.to_string())
+                    .collect::<Vec<String>>()
+                    .join(" OR ")
             ),
         }
     }
@@ -170,8 +182,7 @@ impl VectorStore for Store {
             let id = Uuid::new_v4().to_string();
             ids.push(id.clone());
 
-            let vector_value =
-                Vector::from(vector.iter().map(|x| *x as f32).collect::<Vec<f32>>());
+            let vector_value = Vector::from(vector.iter().map(|x| *x as f32).collect::<Vec<f32>>());
 
             sqlx::query(&format!(
                 r#"INSERT INTO {}

--- a/crates/langchainx-vectorstore/src/qdrant/qdrant.rs
+++ b/crates/langchainx-vectorstore/src/qdrant/qdrant.rs
@@ -50,8 +50,7 @@ impl VectorStore for Store {
             });
 
             if let Some(extra_json) = opt.filters.clone()
-                && let (Value::Object(base_map), Value::Object(extra_map)) =
-                    (&mut base, extra_json)
+                && let (Value::Object(base_map), Value::Object(extra_map)) = (&mut base, extra_json)
             {
                 base_map.extend(extra_map);
             }


### PR DESCRIPTION
## Summary
- Runs `cargo fmt --all` output to fix rustfmt formatting differences that caused CI `fmt-check` to fail after PR #41 merge
- Affected files: deepseek/client.rs, markdown_serializer.rs, language_parsers.rs, postgres.rs, pgvector.rs, qdrant.rs

## Test plan
- [ ] CI `fmt-check` passes
- [ ] CI `build` passes
- [ ] CI `test` passes