### PR TITLE
fix(clippy): unnecessary_unwrap in text2speech and openai stream

### DIFF
--- a/crates/langchainx-llm/src/openai/mod.rs
+++ b/crates/langchainx-llm/src/openai/mod.rs
@@ -142,9 +142,10 @@ impl<C: Config + Send + Sync + 'static> LLM for OpenAI<C> {
         let new_stream = original_stream.map(|result| match result {
             Ok(completion) => {
                 let value_completion = serde_json::to_value(completion).map_err(LLMError::from)?;
-                let usage = value_completion.pointer("/usage");
-                if usage.is_some() && !usage.unwrap().is_null() {
-                    let usage = serde_json::from_value::<TokenUsage>(usage.unwrap().clone())
+                if let Some(usage) = value_completion.pointer("/usage")
+                    && !usage.is_null()
+                {
+                    let usage = serde_json::from_value::<TokenUsage>(usage.clone())
                         .map_err(LLMError::from)?;
                     return Ok(StreamData::new(value_completion, Some(usage), ""));
                 }

--- a/crates/langchainx-tools/src/text2speech/openai/client.rs
+++ b/crates/langchainx-tools/src/text2speech/openai/client.rs
@@ -105,8 +105,7 @@ impl<C: Config + Send + Sync> Tool for Text2SpeechOpenAI<C> {
             .await
             .map_err(|e| ToolError::ExecutionFailed(e.to_string()))?;
 
-        if self.storage.is_some() {
-            let storage = self.storage.as_ref().unwrap(); //safe to unwrap
+        if let Some(storage) = self.storage.as_ref() {
             let data = response.bytes;
             return storage
                 .save(&self.path, &data)


### PR DESCRIPTION
## Summary
- Fix `clippy::unnecessary_unwrap` in `text2speech/openai/client.rs` (use `if let Some`)
- Fix `clippy::unnecessary_unwrap` + `clippy::collapsible_if` in `openai/mod.rs` stream (use `if let ... && !cond`)

These were introduced by the Rust 1.95 clippy version on the CI runner and weren't caught locally.